### PR TITLE
New natrual_sort_key.

### DIFF
--- a/docs/sbpy/data.rst
+++ b/docs/sbpy/data.rst
@@ -564,7 +564,27 @@ would be identified as an asteroid, as it lacks a comet type
 identifier. Hence, some caution is advised when using these routines -
 identification might not be unambiguous.
 
-    
+Sorting names with a natural sort order
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sorting with Python's built-in functions might not return the desired
+order:
+
+    >>> comets = ['9P/Tempel 1',
+    ...           '101P/Chernykh',
+    ...           '10P/Tempel 2',
+    ...           '2P/Encke']
+    >>> sorted(comets)
+    ['101P/Chernykh', '10P/Tempel 2', '2P/Encke', '9P/Tempel 1']
+
+101P and 10P are placed at the start of the list because Python is
+performing a string comparison, which is character-by-character, and
+``'1' < '2'``.  With `sbpy`'s ``natural_sort_key``, numerical
+comparisons are made whenever possible:
+
+    >>> from sbpy.data import natural_sort_key
+    >>> sorted(comets, key=natural_sort_key)
+    ['2P/Encke', '9P/Tempel 1', '10P/Tempel 2', '101P/Chernykh']
 
 
 Reference/API

--- a/sbpy/data/__init__.py
+++ b/sbpy/data/__init__.py
@@ -100,7 +100,7 @@ from .core import (DataClass, mpc_observations, sb_search,
 from .ephem import Ephem
 from .orbit import Orbit
 from .phys import Phys
-from .names import Names
+from .names import Names, natural_sort_key
 
 __all__ = ['DataClass', 'Ephem', 'Orbit', 'Phys', 'Names', 'conf', 'Conf',
            'mpc_observations', 'sb_search', 'image_search',

--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -50,7 +50,7 @@ def natural_sort_key(s):
     """
     import re
     keys = tuple()
-    for k in re.split('([0-9]+)', s):
+    for k in re.split('([0-9]+)', str(s)):
         keys += (int(k) if k.isdigit() else k,)
     return keys
 

--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -13,7 +13,46 @@ created on August 28, 2017
 from .core import DataClass
 from numpy import ndarray
 
-__all__ = ['Names', 'TargetNameParseError']
+__all__ = ['Names', 'TargetNameParseError', 'natural_sort_key']
+
+
+def natural_sort_key(s):
+    """List sort keys considering strings of numbers as integers.
+
+    Intended to be used with `list.sort` or the `sorted` built-in
+    function.
+
+
+    Parameters
+    ----------
+    s : string
+        String to parse into keys.
+
+
+    Returns
+    -------
+    keys : tuple
+        Keys for sorting.
+
+
+    Examples
+    --------
+    >>> from sbpy.data.names import natural_sort_key
+    >>> comets = ['9P/Tempel 1',
+    ...           '101P/Chernykh',
+    ...           '10P/Tempel 2',
+    ...           '2P/Encke']
+    >>> sorted(comets)
+    ['101P/Chernykh', '10P/Tempel 2', '2P/Encke', '9P/Tempel 1']
+    >>> sorted(comets, key=natural_sort_key)
+    ['2P/Encke', '9P/Tempel 1', '10P/Tempel 2', '101P/Chernykh']
+
+    """
+    import re
+    keys = tuple()
+    for k in re.split('([0-9]+)', s):
+        keys += (int(k) if k.isdigit() else k,)
+    return keys
 
 
 class TargetNameParseError(Exception):

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
-from ..names import Names, TargetNameParseError, natrual_sort_key
+from ..names import Names, TargetNameParseError, natural_sort_key
 
 # name: expected result from parse_comet()
 comets = {

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
-from ..names import Names, TargetNameParseError
+from ..names import Names, TargetNameParseError, natrual_sort_key
 
 # name: expected result from parse_comet()
 comets = {
@@ -61,6 +61,13 @@ asteroids = {
                                  '`O`o', 'desig': '2006 RJ110'},
     "(20123) A900 MA": {'number': 20123, 'desig': '1900 MA'}
 }
+
+
+def test_natural_sort_key():
+    items = ['1A10', '1A2', 'B3', 'B20', 'C', '4D', 'CE24', 'CC3D']
+    items = sorted(items, key=natural_sort_key)
+    test = ['1A2', '1A10', '4D', 'B3', 'B20', 'C', 'CC3D', 'CE24']
+    assert all([i == t for i, t in zip(items, test)])
 
 
 def test_asteroid_or_comet():

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -64,9 +64,9 @@ asteroids = {
 
 
 def test_natural_sort_key():
-    items = ['1A10', '1A2', 'B3', 'B20', 'C', '4D', 'CE24', 'CC3D']
+    items = ['1A10', '1A2', 'B3', 'B20', 'C', '4D', 'CE24', 'CC3D', 0]
     items = sorted(items, key=natural_sort_key)
-    test = ['1A2', '1A10', '4D', 'B3', 'B20', 'C', 'CC3D', 'CE24']
+    test = [0, '1A2', '1A10', '4D', 'B3', 'B20', 'C', 'CC3D', 'CE24']
     assert all([i == t for i, t in zip(items, test)])
 
 


### PR DESCRIPTION
Sorting comet names in Python does not return a pleasing order:
```python
>>> comets = ['9P/Tempel 1',
...           '101P/Chernykh',
...           '10P/Tempel 2',
...           '2P/Encke']
>>> sorted(comets)
['101P/Chernykh', '10P/Tempel 2', '2P/Encke', '9P/Tempel 1']
```
Why is 101P before 2P?  Because '101' < '2'.  Instead, the so-called natural order would sort items using numerical comparisons.  Python does not have a natural sort option, but I think we should add one to sbpy because humans like sensible comet and asteroid numbering:
```python
>>> from sbpy.data.names import natural_sort_key
>>> sorted(comets, key=natural_sort_key)
['2P/Encke', '9P/Tempel 1', '10P/Tempel 2', '101P/Chernykh']
```
How about this?