### PR TITLE
bib: Added Filter Functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ astropy-helpers
 matplotlib
 ads
 synphot
-ginga
 git+git://github.com/astropy/astroquery.git@master#egg=astroquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ astropy-helpers
 matplotlib
 ads
 synphot
+ginga
 git+git://github.com/astropy/astroquery.git@master#egg=astroquery

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -87,9 +87,8 @@ class Tracking:
         stop()
 
 
-def to_text():
-    """Convert bibcodes to human readable text.
-
+def to_text(filter=None):
+    """convert bibcodes to human readable text
 
     Returns
     -------
@@ -104,6 +103,10 @@ def to_text():
     for task, ref in _bibliography.items():
         output += '{:s}:\n'.format(task)
         try:
+            if filter is None:
+                pass
+            else:
+                ref = {i: ref[i] for i in ref if i == filter}
             for key, value in ref.items():
                 output += '  {:s}:\n'.format(key)
                 for citation in value:

--- a/sbpy/bib/tests/test_bib.py
+++ b/sbpy/bib/tests/test_bib.py
@@ -84,6 +84,24 @@ def test_Tracking():
     # avoid the build failing because of this we use sets
 
 
+def test_to_text_filter():
+
+    with Tracking():
+        register('test1', {'track_this': 'bibcode1'})
+        register('test1', {'software': 'bibcode2'})
+        register('test1', {'track_this_too': 'bibcode'})
+        register('test2', {'software': 'bibcode'})
+        register('test3', {'track_this': 'bibcode',
+                           'software': 'bibcode'})
+
+    assert set(['test1:', 'software:', 'bibcode2',
+                'test2:', 'software:', 'bibcode',
+                'test3:', 'software:',
+                'bibcode']) == set(to_text(filter='software').split())
+    # different builds will have different orders for bibcode 1 and 2, to
+    # avoid the build failing because of this we use sets
+
+
 def test_Tracking_issue_64():
     from sbpy.activity import photo_lengthscale
     reset()


### PR DESCRIPTION
Added a filter functionality that lets the user filter the bibliography displayed when using `bib.to_text()` function. An example would be setting the filter to 'Software' as such: 
`bib.to_text(filter = 'Software')` which would then filter all the available references tracked by bib that are labeled 'Software'. 