### PR TITLE
Fix for Issue #100: from_horizons now supports multiple Time values

### DIFF
--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -79,7 +79,13 @@ class Ephem(DataClass):
         if epochs is None:
             epochs = [Time.now().jd]
         elif isinstance(epochs, Time):
-            epochs = [Time(epochs).jd]
+            epochs = epochs.jd
+            if isinstance(epochs, float):
+                epochs = [epochs]
+            new_epochs = [None] * len(epochs)
+            for i in range(len(epochs)):
+                new_epochs[i] = epochs[i]
+            epochs = new_epochs
         elif isinstance(epochs, dict):
             for key, val in epochs.items():
                 if isinstance(val, Time):

--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -46,16 +46,16 @@ class Ephem(DataClass):
             ``'name'`` (asteroid or comet name), ``'asteroid_name'``,
             ``'comet_name'``, ``'id'`` (Horizons id).
             Default: ``'smallbody'``
-        epochs : `~astropy.time.Time` object or iterable thereof, or dictionary, optional
-            Epochs of elements to be queried; a list, tuple or
-            `~numpy.ndarray` of `~astropy.time.Time` objects or Julian
-            Dates as floats should be used for a number of discrete
-            epochs; a dictionary including keywords ``start``,
-            ``step``, and ``stop`` can be used to generate a range of
-            epochs (see
+        epochs : `~astropy.time.Time` object, or dictionary of `astropy.time.Time` objects, optional
+            Epochs of elements to be queried; `~astropy.time.Time` objects
+            support iterables within the object so an `~astropy.time.Time`
+            object should still be used for a number of discrete epochs;
+            a dictionary including keywords ``start``, ``step``, and ``stop``
+            and `~astropy.time.Time` objects can be used to generate a range
+            of epochs (see
             `~astroquery.jplhorizons.HorizonsClass.Horizons.ephemerides`
-            for details); if ``None`` is provided, current date and
-            time are used. Default: ``None``
+            for details); if ``None`` is provided, current date and time are
+            used. Default: ``None``
         location : str, optional, default ``'500'`` (geocentric)
             Location of the observer.
         **kwargs : optional
@@ -94,14 +94,6 @@ class Ephem(DataClass):
                     epochs[key] = val.value
                 else:
                     epochs[key] = epochs[key]
-        elif isinstance(epochs, (list, tuple, ndarray)):
-            new_epochs = [None] * len(epochs)
-            for i in range(len(epochs)):
-                if isinstance(epochs[i], Time):
-                    new_epochs[i] = epochs[i].jd
-                else:
-                    new_epochs[i] = epochs[i]
-            epochs = new_epochs
 
         # if targetids is a list, run separate Horizons queries and append
         if not isinstance(targetids, (list, ndarray, tuple)):

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -35,20 +35,8 @@ def test_from_horizons():
     data = Ephem.from_horizons('Ceres', epochs=epochs)
     assert len(data.table) == 13
 
-    # discrete epochs - astropy.time.Time objects
-    epochs = [Time('2018-01-02', format='iso'),
-              Time('2018-01-05', format='iso')]
-    data = Ephem.from_horizons('Ceres', epochs=epochs)
-    assert len(data.table) == 2
-
     # astropy.time.Time object with list of Dates
     epochs = Time(['2018-01-01', '2018-01-02'])
-    data = Ephem.from_horizons('Ceres', epochs=epochs)
-    assert len(data.table) == 2
-
-    # discrete epochs - Julian Dates
-    epochs = [Time('2018-01-02', format='iso').jd,
-              Time('2018-01-05', format='iso').jd]
     data = Ephem.from_horizons('Ceres', epochs=epochs)
     assert len(data.table) == 2
 

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -41,6 +41,11 @@ def test_from_horizons():
     data = Ephem.from_horizons('Ceres', epochs=epochs)
     assert len(data.table) == 2
 
+    # astropy.time.Time object with list of Dates
+    epochs = Time(['2018-01-01', '2018-01-02'])
+    data = Ephem.from_horizons('Ceres', epochs=epochs)
+    assert len(data.table) == 2
+
     # discrete epochs - Julian Dates
     epochs = [Time('2018-01-02', format='iso').jd,
               Time('2018-01-05', format='iso').jd]


### PR DESCRIPTION
This fixes issue #100 to support all instances that are allowed according to the documentation: None, Time object, Time object which date values are a list of dates, dictionaries, plain list of julian dates, and a list of separately created Time objects. If we prefer shorter implementation code we could tweak the documentation to only allow None, dictionaries, or Time objects with either 1 date or a list of dates as such:

`epochs = Time('2015-01-01')`

or

`epochs = Time(['2015-01-01', '2015-01-02'])`

Let me know if there's any advice for anything to add or if we want to limit the user options for the input in order to make the code more concise.