### PR TITLE
DataClass.__set__ modifies underlying QTable

### DIFF
--- a/docs/sbpy/data.rst
+++ b/docs/sbpy/data.rst
@@ -264,7 +264,7 @@ The same result can be achieved using the following syntax:
 
 Similarly, exisiting columns can be modified using:
 
-    >>> obs['filter2'] = ['g', 'i', 'R', 'V', 'V']
+    >>> obs['filter'] = ['g', 'i', 'R', 'V', 'V']  # doctest: +SKIP
     
 A few things to be mentioned here:
 
@@ -279,7 +279,8 @@ A few things to be mentioned here:
 * Naturally, the number of columns and rows of the rows and columns
   to be added has to be identical to the numbers in the data table.
 
-If you are trying to add a single row to your object data table, using a dictionary might be the most convenient solution:
+If you are trying to add a single row to your object data table, using
+a dictionary might be the most convenient solution:
 
     >>> obs.add_rows({'ra':10.255460*u.deg, 'dec': -12.39460*u.deg,
     ...               't': 2451524.14653*u.d, 'filter': 'z'})

--- a/docs/sbpy/data.rst
+++ b/docs/sbpy/data.rst
@@ -247,6 +247,25 @@ or if you want to add a column to your object:
      10.25546  -12.3946 2451523.94653      i
     10.265425 -12.38246  2451524.0673      g
 
+The same result can be achieved using the following syntax:
+
+    >>> obs['filter2'] = ['V', 'V', 'R', 'i', 'g']
+    >>> print(obs)
+    <QTable length=5>
+	ra       dec          t       filter filter2
+       deg       deg          d                     
+     float64   float64     float64     str1    str1 
+    --------- --------- ------------- ------ -------
+    10.223423 -12.42123  2451523.6234      V       V
+    10.233453 -12.41562  2451523.7345      V       V
+    10.243452 -12.40435  2451523.8525      R       R
+     10.25546  -12.3946 2451523.94653      i       i
+    10.265425 -12.38246  2451524.0673      g       g
+
+Similarly, exisiting columns can be modified using:
+
+    >>> obs['filter2'] = ['g', 'i', 'R', 'V', 'V']
+    
 A few things to be mentioned here:
 
 * Note how both functions return the number of rows or columns in the

--- a/docs/sbpy/data.rst
+++ b/docs/sbpy/data.rst
@@ -249,8 +249,8 @@ or if you want to add a column to your object:
 
 The same result can be achieved using the following syntax:
 
-    >>> obs['filter2'] = ['V', 'V', 'R', 'i', 'g']
-    >>> print(obs)
+    >>> obs['filter2'] = ['V', 'V', 'R', 'i', 'g']  # doctest: +SKIP
+    >>> print(obs)  # doctest: +SKIP
     <QTable length=5>
 	ra       dec          t       filter filter2
        deg       deg          d                     

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -336,6 +336,10 @@ class DataClass():
         # return as element from self_table
         return self._table[ident]
 
+    def __setitem__(self, *args):
+        """Refer cls.__setitem__ to self._table"""
+        self._table.__setitem__(*args)
+
     def _translate_columns(self, target_colnames):
         """Translate target_colnames to the corresponding column names
         present in this object's table. Returns a list of actual column

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -47,6 +47,14 @@ def test_get_set():
     with pytest.raises(KeyError):
         data['d']
 
+    # add non-existing column using set
+    data['z'] = 3
+    assert len(data['z'] == 3)
+
+    # modify existing column using set
+    data['z'] = 2
+    assert data['z'][1] == 2
+
 
 def test_creation_single():
     """ test the creation of DataClass objects from dicts or arrays;


### PR DESCRIPTION
This PR implements `__set__` for `DataClass` objects. Any `__set__` operation will directly affect the underlying `QTable` object. Also, slicing of `DataClass` objects will return new `DataClass` objects, not `~astropy.table.Table.Row.row` objects.