### PR TITLE
Remove Cousins I test against Willmer 2018.

### DIFF
--- a/sbpy/units/tests/test_core.py
+++ b/sbpy/units/tests/test_core.py
@@ -58,8 +58,6 @@ def test_spectral_density_vega_wf(wf, fluxd, to):
 
 
 @pytest.mark.parametrize('filename, fluxd, to, tol', (
-    ('cousins_i_004_syn.fits', 2478.76 * u.Jy, 0 * JMmag, 0.015),
-    ('cousins_i_004_syn.fits', 0 * JMmag, 2478.76 * u.Jy, 0.015),
     ('sdss-r.fits', 2.55856e-9 * u.Unit('erg/(s cm2 AA)'), 0 * JMmag,
      0.005),
     ('sdss-r.fits', 0 * JMmag, 2.55856e-9 * u.Unit('erg/(s cm2 AA)'),


### PR DESCRIPTION
Considering this test is almost 2% off from the "true" value, and that the bandpass we have in sbpy (from Maíz Apellániz 2006) is probably subtly different from the one used by Willmer 2018 (Mann & von Braun 2015), I propose we remove it.