### PR TITLE
Fixed input to  production rate functions so as to follow sbpy rules

### DIFF
--- a/docs/sbpy/spectroscopy.rst
+++ b/docs/sbpy/spectroscopy.rst
@@ -14,10 +14,12 @@ JPLSpec Constants and Line Intensity Integral Conversion
 `sbpy.spectroscopy` has a function called ``molecular_data`` which takes care of
 querying the JPL Molecular Spectral Catalog through the use of
 `astroquery.jplspec` and calculates all the necessary constants needed for both
-production rate and Einstein coefficient calculations. The function
-``intensity_conversion`` takes care of converting the intensity line integral at
-300 K found in JPL Spec catalog and convert it closer to the temperature given
-by the user.
+production rate and Einstein coefficient calculations. ``molecular_data``
+returns an `sbpy.data.phys` instance with quantities in the order of: Transition
+Frequency, Temperature, Integrated line intensity at 300 K, and Partition
+function at 300 K. The function ``intensity_conversion`` takes care of
+converting the intensity line integral at 300 K found in JPL Spec catalog and
+convert it closer to the temperature given by the user.
 
 .. code-block:: python
 
@@ -82,18 +84,21 @@ section.
 .. code-block:: python
 
   >>> from sbpy.spectroscopy import prodrate_np
+  >>> from astropy.time import Time
+  >>> from sbpy.data import Ephem
   >>> temp_estimate = 33. * u.K
-  >>> target = '900918'
+  >>> target = '103P'
   >>> vgas = 0.8 * u.km / u.s
   >>> aper = 30 * u.m
   >>> b = 1.13
   >>> mol_tag = 27001
   >>> transition_freq = 265.886434 * u.MHz
   >>> spectra = 1.22 * u.K * u.km / u.s
-  >>> time = '2010-11-3 00:48:06'
+  >>> time = Time('2010-11-3 00:48:06', format='iso')
+  >>> ephemobj = Ephem(target, epochs=time.jd, id_type='id')
   >>> q = prodrate_np(spectra, temp_estimate, transition_freq,
-                            mol_tag, time, target, vgas, aper,
-                            b=b, id_type='id')
+                            mol_tag, ephemobj, vgas, aper,
+                            b=b)
 
   >>> q
   <Quantity 1.0432591198553935e+25 1 / s>
@@ -113,6 +118,8 @@ model does account for the effects of photolysis.
 .. code-block:: python
 
   >>> from sbpy.activity.gas import Haser
+  >>> from astropy.time import Time
+  >>> from sbpy.data import Ephem
   >>> coma = Haser(Q, v, parent)
   >>> Q = spec.production_rate(coma, molecule='H2O')
 
@@ -126,6 +133,7 @@ model does account for the effects of photolysis.
   >>> vgas = 0.5 * u.km / u.s
 
   >>> time = '2017-12-22 05:24:20'
+  >>> ephemobj = Ephem(target, epochs=time.jd)
   >>> spectra = 0.26 * u.K * u.km / u.s
 
   >>> parent = photo_timescale('CO') * vgas
@@ -133,7 +141,7 @@ model does account for the effects of photolysis.
   >>> coma = Haser(Q_estimate, vgas, parent)
 
   >>> Q = spec.production_rate(coma, spectra, temp_estimate,
-                               transition_freq, mol_tag, time, target,
+                               transition_freq, mol_tag, ephemobj,
                                aper=aper, b=b)
 
   >>> print(Q)
@@ -169,7 +177,7 @@ The names of the built-in sources are stored as an internal array.  They can be 
 
   >>> from sbpy.spectroscopy import Sun
   >>> Sun.show_builtin()
-      name                                description                           
+      name                                description
   ------------ -----------------------------------------------------------------
      E490_2014                E490-00a (2014) reference solar spectrum (Table 3)
    E490_2014LR E490-00a (2014) low resolution reference solar spectrum (Table 4)

--- a/sbpy/spectroscopy/core.py
+++ b/sbpy/spectroscopy/core.py
@@ -475,14 +475,8 @@ class Spectrum():
         temp_estimate : `~astropy.units.Quantity`
             Estimated temperature in Kelvins
 
-        time : str
-            Time of observation of any format supported by `~astropy.time`
-
-        target : str
-            | Target designation, if there is more than one aparition you
-            | will be prompted to pick a more specific identifier from a
-            | displayed table and change the parameter id_type to 'id'.
-            | Look at `~astroquery.jplhorizons` for more information.
+        ephemobj: `~sbpy.data.Ephem` object
+            An `~sbpy.data.Ephem` object that holds ephemerides information
 
         mol_tag : int or str
             Molecule identifier. Make sure it is an exclusive identifier.
@@ -493,26 +487,10 @@ class Spectrum():
         aper : `~astropy.units.Quantity`
             Telescope aperture in meters. Default is 25 m
 
-        observatory : str
-            | Observatory identifier as per `~astroquery.jplhorizons`
-            | Default is geocentric ('500')
-
         b : int
             | Dimensionless factor intrinsic to every antenna. Typical
             | value, and the default for this model, is 1.22. See
             | references for more information on this parameter.
-
-        time_format : str
-            | Time format, see `~astropy.time` for more information
-            | Default is 'iso' which corresponds to 'YYYY-MM-DD HH:MM:SS'
-
-        time_scale : str
-            | Time scale, see `~astropy.time` for mor information.
-            | Default is 'utc'
-
-        id_type : str
-            | ID type for target. See `~astroquery.jplhorizons` for more.
-            | Default is 'designation'
 
         Returns
         -------
@@ -522,6 +500,10 @@ class Spectrum():
         Examples
         --------
         >>> import astropy.units as u  # doctest: +SKIP
+
+        >>> from astropy.time import Time # doctest: +SKIP
+
+        >>> from sbpy.data import Ephem # doctest: +SKIP
 
         >>> from sbpy.spectroscopy import prodrate_np  # doctest: +SKIP
 
@@ -541,11 +523,12 @@ class Spectrum():
 
         >>> spectra = 1.22 * u.K * u.km / u.s  # doctest: +SKIP
 
-        >>> time = '2010-11-3 00:48:06'  # doctest: +SKIP
+        >>> time = Time('2010-11-3 00:48:06', format='iso')  # doctest: +SKIP
+
+        >>> ephemobj = Ephem(target, epochs=time.jd, id_type='id') # doctest: +SKIP
 
         >>> q = prodrate_np(spectra, temp_estimate, transition_freq, # doctest: +SKIP
-                            mol_tag, time, target, vgas, aper,
-                            b=b, id_type='id')
+                            mol_tag, ephemobj, vgas, aper, b=b)
 
         >>> q  # doctest: +SKIP
         <Quantity 1.0432591198553935e+25 1 / s>
@@ -679,38 +662,16 @@ class Spectrum():
         mol_tag : int or str
             Molecule identifier. Make sure it is an exclusive identifier.
 
-        time : str
-            Time of observation of any format supported by `~astropy.time`
-
-        target : str
-            | Target designation, if there is more than one aparition you
-            | will be prompted to pick a more specific identifier from a
-            | displayed table and change the parameter id_type to 'id'.
-            | Look at `~astroquery.jplhorizons` for more information.
+        ephemobj: `~sbpy.data.Ephem` object
+            An `~sbpy.data.Ephem` object that holds ephemerides information
 
         aper : `~astropy.units.Quantity`
             Telescope aperture in meters. Default is 25 m
-
-        observatory : str
-            | Observatory identifier as per `~astroquery.jplhorizons`
-            | Default is geocentric ('500')
 
         b : int
             | Dimensionless factor intrinsic to every antenna. Typical
             | value, and the default for this model, is 1.22. See
             | references for more information on this parameter.
-
-        time_format : str
-            | Time format, see `~astropy.time` for more information
-            | Default is 'iso' which corresponds to 'YYYY-MM-DD HH:MM:SS'
-
-        time_scale : str
-            | Time scale, see `~astropy.time` for mor information.
-            | Default is 'utc'
-
-        id_type : str
-            | ID type for target. See `~astroquery.jplhorizons` for more.
-            | Default is 'designation'
 
         Returns
         -------
@@ -720,6 +681,9 @@ class Spectrum():
         Examples
         --------
         >>> from sbpy.activity.gas import Haser # doctest: +SKIP
+        >>> from sbpy.data import Ephem # doctest: +SKIP
+        >>> from astropy.time import Time # doctest: +SKIP
+
         >>> coma = Haser(Q, v, parent) # doctest: +SKIP
         >>> Q = spec.production_rate(coma, molecule='H2O') # doctest: +SKIP
 
@@ -732,7 +696,8 @@ class Spectrum():
         >>> b = 0.74 # doctest: +SKIP
         >>> vgas = 0.5 * u.km / u.s # doctest: +SKIP
 
-        >>> time = '2017-12-22 05:24:20' # doctest: +SKIP
+        >>> time = Time('2017-12-22 05:24:20', format = 'iso') # doctest: +SKIP
+        >>> ephemobj = Ephem(target, epochs=time.jd) # doctest: +SKIP
         >>> spectra = 0.26 * u.K * u.km / u.s # doctest: +SKIP
 
         >>> parent = photo_timescale('CO') * vgas # doctest: +SKIP
@@ -740,7 +705,7 @@ class Spectrum():
         >>> coma = Haser(Q_estimate, vgas, parent) # doctest: +SKIP
 
         >>> Q = spec.production_rate(coma, spectra, temp_estimate, # doctest: +SKIP
-                                     transition_freq, mol_tag, time, target,
+                                     transition_freq, mol_tag, ephemobj,
                                      aper=aper, b=b) # doctest: +SKIP
 
         >>> print(Q) # doctest: +SKIP

--- a/sbpy/spectroscopy/core.py
+++ b/sbpy/spectroscopy/core.py
@@ -509,7 +509,7 @@ class Spectrum():
 
         >>> temp_estimate = 33. * u.K  # doctest: +SKIP
 
-        >>> target = '900918'  # doctest: +SKIP
+        >>> target = '103P'  # doctest: +SKIP
 
         >>> vgas = 0.8 * u.km / u.s  # doctest: +SKIP
 
@@ -625,7 +625,7 @@ class Spectrum():
             au = einstein_coeff(temp_estimate, transition_freq, mol_tag)
 
             photod = photod_rate(ephemobj, mol_tag)
-            
+
             delta = photod["delta"]
 
             calc = ((16*np.pi*k*t_freq.decompose() *

--- a/sbpy/spectroscopy/tests/test_spec_remote.py
+++ b/sbpy/spectroscopy/tests/test_spec_remote.py
@@ -2,11 +2,13 @@ import os
 
 import numpy as np
 import astropy.units as u
+from astropy.time import Time
 from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astroquery.lamda import Lamda
 from astroquery.jplspec import JPLSpec
 from ...activity.gas import Haser, photo_timescale
+from ...data import Ephem
 from .. import Spectrum, einstein_coeff
 
 
@@ -33,14 +35,14 @@ def test_remote_prodrate_simple_hcn():
 
     for i in range(0, 28):
 
-        time = hcn['Time'][i]
+        time = Time(hcn['Time'][i], format='iso')
         spectra = hcn['T_B'][i] * u.K * u.km / u.s
+        ephemobj = Ephem.from_horizons(target, epochs=time.jd, id_type='id')
 
         s = Spectrum(spectra, dispersionaxis, unit)
 
         q = s.prodrate_np(spectra, temp_estimate, transition_freq,
-                          mol_tag, time, target, vgas, aper, b=b,
-                          id_type='id')
+                          mol_tag, ephemobj, vgas, aper, b=b)
 
         q = np.log10(q.value)
 
@@ -76,14 +78,14 @@ def test_remote_prodrate_simple_ch3oh():
 
     for i in range(0, 20):
 
-        time = ch3oh['Time'][i]
+        time = Time(ch3oh['Time'][i], format='iso')
         spectra = ch3oh['T_B'][i] * u.K * u.km / u.s
+        ephemobj = Ephem.from_horizons(target, epochs=time.jd, id_type='id')
 
         s = Spectrum(spectra, dispersionaxis, unit)
 
         q = s.prodrate_np(spectra, temp_estimate, transition_freq,
-                          mol_tag, time, target, vgas, aper, b=b,
-                          id_type='id')
+                          mol_tag, ephemobj, vgas, aper, b=b)
 
         q = np.log10(q.value)
 
@@ -162,15 +164,16 @@ def test_Haser_prodrate():
 
     for i in range(0, 5):
 
-        time = co['Time'][i]
+        time = Time(co['Time'][i], format='iso')
         spectra = co['T_B'][i] * u.K * u.km / u.s
+        ephemobj = Ephem.from_horizons(target, epochs=time.jd)
 
         parent = photo_timescale('CO') * vgas
 
         coma = Haser(Q_estimate, vgas, parent)
 
         Q = spec.production_rate(coma, spectra, temp_estimate,
-                                 transition_freq, mol_tag, time, target,
+                                 transition_freq, mol_tag, ephemobj,
                                  aper=aper, b=b)
 
         q_found.append(np.log10(Q.value)[0])


### PR DESCRIPTION
This pull request fixes the inputs to the production rate functions within `sbpy.spectrocopy` so as to follow the rules put forth recently which can be viewed under [this link](https://github.com/NASA-Planetary-Science/sbpy/wiki/function-method-design). This PR complements the changes made under PR #140. 