### PR TITLE
Fix infrastructure and sphinx issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ addons:
             - graphviz
 
 stages:
-   - name: Build tests 
+   - name: Build tests
    - name: Tests with various Astropy/Numpy versions
    - name: Test docs, PEP8, and coverage
    - name: Remote data tests (allowed to fail)
-   
+
 stage: Build tests
 
 # setting up environment variables and the build matrix
@@ -33,7 +33,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - PIP_DEPENDENCIES='numpy scipy matplotlib ads synphot https://github.com/astropy/astroquery/archive/master.zip pytest-astropy sphinx-astropy'
+        - PIP_DEPENDENCIES='scipy matplotlib ads synphot https://github.com/astropy/astroquery/archive/master.zip pytest-astropy'
         - ADS_DEV_KEY=TjUyPHFOH48m5Katkeq0UCZQcejTg6bDbTuTGHxT
 
     matrix:
@@ -59,15 +59,15 @@ matrix:
         - os: linux
           stage: Tests with various Astropy/Numpy versions
           env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.14 ASTROPY_VERSION=3 PYTEST_VERSION='<3.7'
-          
+
         # Test docs, PEP8, and coverage
         - os: linux
           stage: Test docs, PEP8, and coverage
-          env: MAIN_CMD='test --coverage' SETUP_CMD=''  
+          env: MAIN_CMD='test --coverage' SETUP_CMD=''
 
         - os: linux
           stage: Test docs, PEP8, and coverage
-          env: SETUP_CMD='build_docs -w'        
+          env: SETUP_CMD='build_docs -w' PIP_DEPENDENCIES="`echo $PIP_DEPENDENCIES sphinx-astropy`"
 
         - os: linux
           stage: Test docs, PEP8, and coverage

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -48,10 +48,7 @@ import sys
 from distutils import log
 from distutils.debug import DEBUG
 
-try:
-    from ConfigParser import ConfigParser, RawConfigParser
-except ImportError:
-    from configparser import ConfigParser, RawConfigParser
+from configparser import ConfigParser, RawConfigParser
 
 import pkg_resources
 
@@ -123,20 +120,22 @@ if SETUP_CFG.has_option('options', 'python_requires'):
 
     if not req.specifier.contains(python_version):
         if parent_package is None:
-            print("ERROR: Python {} is required by this package".format(req.specifier))
+            message = "ERROR: Python {} is required by this package\n".format(req.specifier)
         else:
-            print("ERROR: Python {} is required by {}".format(req.specifier, parent_package))
+            message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
+        sys.stderr.write(message)
         sys.exit(1)
 
 if sys.version_info < __minimum_python_version__:
 
     if parent_package is None:
-        print("ERROR: Python {} or later is required by astropy-helpers".format(
-            __minimum_python_version__))
+        message = "ERROR: Python {} or later is required by astropy-helpers\n".format(
+            __minimum_python_version__)
     else:
-        print("ERROR: Python {} or later is required by astropy-helpers for {}".format(
-            __minimum_python_version__, parent_package))
+        message = "ERROR: Python {} or later is required by astropy-helpers for {}\n".format(
+            __minimum_python_version__, parent_package)
 
+    sys.stderr.write(message)
     sys.exit(1)
 
 _str_types = (str, bytes)
@@ -146,14 +145,14 @@ _str_types = (str, bytes)
 # issues with either missing or misbehaving pacakges (including making sure
 # setuptools itself is installed):
 
-# Check that setuptools 1.0 or later is present
+# Check that setuptools 30.3 or later is present
 from distutils.version import LooseVersion
 
 try:
     import setuptools
-    assert LooseVersion(setuptools.__version__) >= LooseVersion('1.0')
+    assert LooseVersion(setuptools.__version__) >= LooseVersion('30.3')
 except (ImportError, AssertionError):
-    print("ERROR: setuptools 1.0 or later is required by astropy-helpers")
+    sys.stderr.write("ERROR: setuptools 30.3 or later is required by astropy-helpers\n")
     sys.exit(1)
 
 # typing as a dependency for 1.6.1+ Sphinx causes issues when imported after

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,20 +30,10 @@ import os
 import sys
 
 try:
-    from sphinx_astropy.conf import *
+    from sphinx_astropy.conf.v1 import *
 except ImportError:
     print('ERROR: the documentation requires the sphinx-astropy package to be installed')
     sys.exit(1)
-
-try:
-    import astropy_helpers
-except ImportError:
-    # Building from inside the docs/ directory?
-    if os.path.basename(os.getcwd()) == 'docs':
-        a_h_path = os.path.abspath(os.path.join('..', 'astropy_helpers'))
-        if os.path.isdir(a_h_path):
-            sys.path.insert(1, a_h_path)
-
 
 # Get configuration information from setup.cfg
 try:
@@ -167,7 +157,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 # -- Options for the edit_on_github extension ---------------------------------
 
 if eval(setup_cfg.get('edit_on_github')):
-    extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
+    extensions += ['sphinx_astropy.ext.edit_on_github']
 
     versionmod = __import__(setup_cfg['package_name'] + '.version')
     edit_on_github_project = setup_cfg['github_project']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ Most requirements should be resolved during the installation process. However, w
 
 .. code-block:: bash
 
-    $ pip install git+https://github.com/astropy/astroquery.git
+    $ pip install --pre astroquery
 
 Also, if you want to use `pyoorb
 <https://github.com/oorb/oorb/tree/master/python>`__, you will have to
@@ -108,7 +108,7 @@ The `sbpy` team maintains a `tutorial repository
 <https://github.com/NASA-Planetary-Science/sbpy-tutorial>`__ providing
 tutorials and learning materials used in workshops. Upcoming workshops
 are also announced on this website.
-   
+
 
 Current Status
 --------------
@@ -117,7 +117,7 @@ This package is currently under heavy development. For an overview on
 the expected structure and functionality of `sbpy`, please refer to
 :doc:`structure` page; the :doc:`status` provides an overview on the
 implementation status of all modules and functions.
-	  
+
 The current development version status is as follows:
 
 .. image:: https://travis-ci.org/NASA-Planetary-Science/sbpy.svg?branch=master
@@ -127,7 +127,7 @@ The current development version status is as follows:
 .. image:: https://coveralls.io/repos/github/NASA-Planetary-Science/sbpy/badge.svg?branch=master
     :target: https://coveralls.io/github/NASA-Planetary-Science/sbpy?branch=master
     :alt: Coveralls status
-	
+
 .. image:: https://readthedocs.org/projects/sbpy/badge/?version=latest
     :target: http://sbpy.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
@@ -137,13 +137,13 @@ More information on `sbpy`
 --------------------------
 
 .. toctree::
-   :maxdepth: 1  
+   :maxdepth: 1
 
    contributing.rst
    structure.rst
    status.rst
 
-   
+
 Reference/API
 -------------
 
@@ -176,7 +176,7 @@ Acknowledgments
 `sbpy` is supported by NASA PDART Grant No. 80NSSC18K0987.
 
 If you use `sbpy` in your work, please acknowledge it using the following line:
-   
+
    "*This work made use of sbpy (http://sbpy.org), a community-driven Python package for small-body planetary astronomy supported by NASA PDART Grant No. 80NSSC18K0987.*"
 
 and also please consider using the `~sbpy.bib` reference tracking

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy>=1.4.0
-astropy-helpers
 matplotlib
 ads
 synphot

--- a/sbpy/conftest.py
+++ b/sbpy/conftest.py
@@ -2,37 +2,46 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
+from astropy.version import version as astropy_version
+
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions
 # enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
-# try:
-#     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-#     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
-#     del PYTEST_HEADER_MODULES['h5py']
-# except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-#     pass
+# Uncomment and customize the following lines to add/remove entries from
+# the list of packages for which version numbers are displayed when running
+# the tests. Making it pass for KeyError is essential in some cases when
+# the package uses other astropy affiliated packages.
+try:
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['astroquery'] = 'astroquery'
+    del PYTEST_HEADER_MODULES['h5py']
+except KeyError:
+    pass
 
-## Uncomment the following lines to display the version number of the
-## package rather than the version number of Astropy in the top line when
-## running the tests.
-# import os
-#
-## This is to figure out the affiliated package version, rather than
-## using Astropy's
-# try:
-#     from .version import version
-# except ImportError:
-#     version = 'dev'
-#
-# try:
-#     packagename = os.path.basename(os.path.dirname(__file__))
-#     TESTED_VERSIONS[packagename] = version
-# except NameError:   # Needed to support Astropy <= 1.0.0
-#     pass
+# Uncomment the following lines to display the version number of the
+# package rather than the version number of Astropy in the top line when
+# running the tests.
+import os
+
+# This is to figure out the affiliated package version, rather than
+# using Astropy's
+try:
+    from .version import version, astropy_helpers_version
+except ImportError:
+    version = 'dev'
+
+packagename = os.path.basename(os.path.dirname(__file__))
+TESTED_VERSIONS[packagename] = version
+TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version


### PR DESCRIPTION
This PR brings the helpers back to the latest release (this one is now 3.2rc1, but I'll revert back to 3.1.1 in case there are some issues). 

Also clears up the template to rely less on the helpers. 