### PR TITLE
Better documentation for exceptions, introduce sbpy warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ docs/_build
 # Packages/installer info
 *.egg
 *.egg-info
+.eggs
 dist
 build
 eggs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -162,6 +162,7 @@ Reference/API
    sbpy/utils.rst
    sbpy/obsutil.rst
    sbpy/bib.rst
+   sbpy/exceptions.rst
 
 
 External packages that have been modified as part of `sbpy`

--- a/docs/sbpy/exceptions.rst
+++ b/docs/sbpy/exceptions.rst
@@ -1,0 +1,23 @@
+Exceptions Module (`sbpy.exceptions`)
+=====================================
+
+Introduction
+------------
+
+`~sbpy.exceptions` provides the ``SbpyExecption`` and ``SbpyWarning`` base classes, from which all sbpy-specific exceptions and warnings should be derived.
+
+To suppress all sbpy warnings:
+
+```
+import warnings
+from sbpy.exceptions import SbpyWarning
+warnings.simplefilter('ignore', SbpyWarning)
+```
+
+See the `Astropy documentation <http://docs.astropy.org/en/stable/warnings.html>`_ for more ways to suppress warnings.
+
+
+Reference/API
+-------------
+.. automodapi:: sbpy.exceptions
+    :no-heading:

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -39,7 +39,7 @@ from astropy.utils.exceptions import AstropyWarning
 from .. import bib
 from ..spectroscopy import Sun, BlackbodySource
 from ..data import Ephem
-from ..exceptions import SinglePointSpectrumError
+from ..spectroscopy.sources import SinglePointSpectrumError
 from .core import Aperture, rho_as_length
 
 

--- a/sbpy/exceptions.py
+++ b/sbpy/exceptions.py
@@ -1,10 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""sbpy exceptions and warnings
+
+General exceptions/warnings for all of sbpy are specified below.
+Exceptions and warnings that are sub-module specific should be in the
+respective sub-module.
+
+"""
 
 
 class SbpyException(Exception):
-    pass
+    """Exception base class for all sbpy exceptions."""
 
 
-class SinglePointSpectrumError(SbpyException):
-    '''Single point provided, but multiple values expected.'''
-    pass
+class SbpyWarning(Warning):
+    """Warning base class for all sbpy warnings."""

--- a/sbpy/spectroscopy/core.py
+++ b/sbpy/spectroscopy/core.py
@@ -96,7 +96,8 @@ def molecular_data(temp_estimate, transition_freq, mol_tag):
     energy_J = energy.to(u.J, equivalencies=u.spectral())
     elo_J = elo.to(u.J, equivalencies=u.spectral())
 
-    quantities = [t_freq, temp, lgint, part300, partition, gu, energy_J, elo_J, df]
+    quantities = [t_freq, temp, lgint, part300,
+                  partition, gu, energy_J, elo_J, df]
     names = ('Transition frequency',
              'Temperature',
              'Integrated line intensity at 300 K',

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -15,8 +15,12 @@ __all__ = [
 from abc import ABC
 import numpy as np
 import astropy.units as u
-from ..exceptions import SinglePointSpectrumError
+from ..exceptions import SbpyException
 from ..bib import register
+
+
+class SinglePointSpectrumError(SbpyException):
+    '''Single point provided, but multiple values expected.'''
 
 
 class SpectralSource(ABC):

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -8,9 +8,8 @@ import astropy.units as u
 from astropy.tests.helper import remote_data
 from astropy.modeling.blackbody import blackbody_nu, blackbody_lambda
 import synphot
-from ..sources import SpectralStandard, BlackbodySource
+from ..sources import SpectralStandard, BlackbodySource, SinglePointSpectrumError
 from ... import bib, units, utils
-from ... import exceptions as sbe
 
 
 class Star(SpectralStandard):
@@ -146,9 +145,9 @@ class TestSpectralStandard:
         w = u.Quantity(np.linspace(0.3, 1.0), 'um')
         f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
         s = Star.from_array(w, f)
-        with pytest.raises(sbe.SinglePointSpectrumError):
+        with pytest.raises(SinglePointSpectrumError):
             s.observe(1 * u.um)
-        with pytest.raises(sbe.SinglePointSpectrumError):
+        with pytest.raises(SinglePointSpectrumError):
             s.observe([1] * u.um)
 
     def test_bibcode(self):


### PR DESCRIPTION
Move SinglePointSpectrumError to spectroscopy.source