### PR TITLE
Simplfy cite

### DIFF
--- a/docs/sbpy/bib.rst
+++ b/docs/sbpy/bib.rst
@@ -12,34 +12,35 @@ designed methods and tools used.
 ADS Query Requirements for the `sbpy.bib` Module
 ------------------------------------------------
 
-In order to use the `~sbpy.bib` functionality and obtain author names from
-the bibcode provided by the user, the user has to have the `ads` module
-installed. More information on this module is found in:
-<a href="https://ads.readthedocs.io/en/latest/"> ads Docs </a>. In order
-for the ads queries, essential to `sbpy.bib`, to work the user has to have
-the module installed, and their own personal developer key.
-As stated in the documentation:
+In order to use the `~sbpy.bib` functionality and obtain author names
+from the bibcode provided by the user, the user has to have the `~ads`
+module installed. More information on this module is found in the `ads
+Docs <https://ads.readthedocs.io/en/latest/>`_. In order for the
+`~ads` queries, essential to `~sbpy.bib`, to work the user has to have
+the module installed, and their own personal developer key.  As stated
+in the documentation:
 
-1. You'll need an API key from NASA ADS labs. Sign up for the newest version
-of ADS search at <a href="https://ui.adsabs.harvard.edu"> ADS search </a>,
-visit account settings and generate a new API token.
+1. You'll need an API key from NASA ADS labs. Get `an ADS account
+<https://ui.adsabs.harvard.edu/user/account/register>`_, visit account
+settings and generate a new API token.
 
-2. When you get your API key, save it to a file called `~/.ads/dev_key` or
-save it as an environment variable named `ADS_DEV_KEY`
+2. When you get your API key, save it to a file called ``~/.ads/dev_key`` or
+save it as an environment variable named ``ADS_DEV_KEY``
 
-3. From terminal type `pip install ads`
+3. Install the `ads` python module, e.g., if using pip: ``pip install ads``
 
 How to use `~sbpy.bib`
 ----------------------
 
-Use `~sbpy.bib.track` to enable citation tracking. Every method called
-after activating the tracking will register citations relevant to
-it. Each citation is associated with a tag that enables the user to
-identify which aspect of the method the citation is relevant to:
+Use `~sbpy.bib.track()` to enable citation tracking. Every method
+called after activating the tracking will register any relevant
+citations. Each citation is associated with a tag that enables the
+user to identify which aspect of the method the citation is relevant
+to:
 
     >>> from sbpy import bib, data
     >>> bib.track()
-    >>> eph = data.Ephem.from_horizons('433', epochs=None, location='500')
+    >>> eph = data.Ephem.from_horizons('433')
     >>> print(bib.to_text())  # doctest: +SKIP
     sbpy.data.Ephem.from_horizons:
       data service:
@@ -54,23 +55,41 @@ simple text form.
 
 Bibliography tracking can also be used in a context manager:
 
-    >>> from sbpy import bib
-    >>> from sbpy.data import Ephem
+    >>> from sbpy import bib, data
     >>> with bib.Tracking(to_text):
-    ...     eph = Ephem.from_horizons('Ceres', epochs=None, location='500')
+    ...     eph = data.Ephem.from_horizons('Ceres')
     ...     # doctest: +SKIP
     sbpy.data.Ephem.from_horizons:
       data service:
           Giorgini, Yeomans, Chamberlin et al. 1996, AAS/Division for Planetary Sciences Meeting Abstracts #28, 25.04
+
+Automatic reporting
+-------------------
+
+If tracking is enabled when Python exits, the bibliography will be automatically reported.  ``ipython`` users can enable tracking at startup so that no citations are left behind.  For example, add the following to a startup script, such as ``~/.ipython/profile_default/startup/99-user.py``:
+
+.. code-block:: python
+
+    import sbpy.bib
+    sbpy.bib.track()
+
 
 Output formats
 --------------
 
 Bibliographies can be generated in different output formats:
 
+Unformatted (`~sbpy.bib.show`)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    >>> bib.show() # doctest: +SKIP
+    sbpy.data.Ephem.from_horizons:
+      data service:
+        1996DPS....28.2504G
+
+
 Simple text (`~sbpy.bib.to_text`)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    >>> bib.to_text()  # doctest: +SKIP
+    >>> bib.to_text() # doctest: +SKIP
     sbpy.data.Ephem.from_horizons:
       data service:
           Giorgini, Yeomans, Chamberlin et al. 1996, AAS/Division for Planetary Sciences Meeting Abstracts #28, 25.04

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -424,11 +424,11 @@ def to_mnras(filter=None):
 
 @atexit.register
 def _report_at_exit():
-    if _track:
+    if status():
         log.info('Thank you for using sbpy.  ' +
                  'Your session results were based on:\n' +
                  to_text())
 
 
-_track = False  # default is no bibliography tracking
+stop()  # default is no bibliography tracking
 reset()  # creates empty _bibliography

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -28,7 +28,7 @@ import atexit
 from astropy import log
 
 
-def register(task, citation):
+def register(task, citations):
     """Register a citation with the `sbpy` bibliography tracker.
 
 
@@ -37,11 +37,12 @@ def register(task, citation):
     task : string
         The name of the source module requesting a citation.
 
-    citation : dict
-        A dictionary of a single NASA Astrophysics Data System (ADS)
-        bibcode to cite.  The key references the aspect that requires
-        citation, e.g., `{'method': '1998Icar..131..291H'}`, or
-        `{'beaming parameter': '2013Icar..226.1138F'}`.
+    citations : dict
+        A dictionary of NASA Astrophysics Data System (ADS) bibcodes,
+        DOIs, or free-form strings to cite.  The key references the
+        aspect that requires citation, e.g., `{'method':
+        '1998Icar..131..291H'}`, or `{'beaming parameter':
+        '2013Icar..226.1138F'}`.
 
     """
     global _bibliography, _track
@@ -104,18 +105,20 @@ class Tracking:
             print(self.reporter())
 
 
-def cite(key, reference):
-    """Decorator that registers citations with ``sbpy.bib``.
+def cite(citations):
+    """Decorator that registers citations within ``sbpy``.
 
+    This decorator is the primary mechanism for registering citations.
+    As an alternative, `~register` may be called directly.
 
     Parameters
     ----------
-    key : string
-        Citation key, e.g., 'method', or 'beaming parameter'.
-
-    reference : string
-        A NASA ADS key, DOI, or text describing the reference.
-
+    citations : dict
+        A dictionary of NASA Astrophysics Data System (ADS) bibcodes,
+        DOIs, or free-form strings to cite.  The key references the
+        aspect that requires citation, e.g., `{'method':
+        '1998Icar..131..291H'}`, or `{'parameter : beaming':
+        '2013Icar..226.1138F'}`.
 
     Returns
     -------
@@ -125,7 +128,7 @@ def cite(key, reference):
 
     Examples
     --------
-    >>> @cite('method', '1687pnpm.book.....N')
+    >>> @cite({'method': '1687pnpm.book.....N'})
     ... def force(mass, accelleration):
     ...     return mass * accelleration
     >>>

--- a/sbpy/bib/tests/test_bib.py
+++ b/sbpy/bib/tests/test_bib.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import pytest
-import time
-from ...thermal import NEATM
-from .. import (track, stop, register, reset, to_text, to_bibtex,
+from .. import (track, stop, register, reset, cite, show, to_text, to_bibtex,
                 to_aastex, to_icarus, to_mnras, Tracking)
 
 
@@ -64,6 +62,34 @@ def data_path(filename):
 #     print(to_text().split())
 
 
+def test_register_single():
+    reset()
+    with Tracking():
+        register('test1', {'track_this': 'bibcode1'})
+
+    assert (set(['test1:', 'track_this:', 'bibcode1'])
+            == set(show().split()))
+
+
+def test_register_list():
+    reset()
+    with Tracking():
+        register('test1', {'track_this': ['bibcode1', 'bibcode2']})
+
+    assert (set(['test1:', 'track_this:', 'bibcode1', 'bibcode2'])
+            == set(show().split()))
+
+
+def test_register_double():
+    reset()
+    with Tracking():
+        register('test1', {'track_this': ['bibcode1', 'bibcode2']})
+        register('test1', {'track_this': ['bibcode2']})
+        register('test1', {'track_this': ['bibcode3']})
+
+    assert show().count('bibcode2') == 1
+
+
 def test_Tracking():
     reset()
 
@@ -79,13 +105,12 @@ def test_Tracking():
     assert set(['test1:', 'track_this:', 'bibcode1', 'bibcode2',
                 'track_this_too:', 'bibcode', 'test2:', 'track_this:',
                 'bibcode', 'test3:', 'track_this:', 'bibcode',
-                'and_track_that:', 'bibcode']) == set(to_text().split())
+                'and_track_that:', 'bibcode']) == set(show().split())
     # different builds will have different orders for bibcode 1 and 2, to
     # avoid the build failing because of this we use sets
 
 
-def test_to_text_filter():
-
+def test_filter():
     with Tracking():
         register('test1', {'track_this': 'bibcode1'})
         register('test1', {'software': 'bibcode2'})
@@ -97,7 +122,7 @@ def test_to_text_filter():
     assert set(['test1:', 'software:', 'bibcode2',
                 'test2:', 'software:', 'bibcode',
                 'test3:', 'software:',
-                'bibcode']) == set(to_text(filter='software').split())
+                'bibcode']) == set(show(filter='software').split())
     # different builds will have different orders for bibcode 1 and 2, to
     # avoid the build failing because of this we use sets
 
@@ -108,6 +133,6 @@ def test_Tracking_issue_64():
     with Tracking():
         gamma_H2O = photo_lengthscale('H2O')
         gamma_OH = photo_lengthscale('OH')
-    words = to_text().split()
+    words = show().split()
     assert 'OH' in words
     assert 'H2O' in words


### PR DESCRIPTION
Simplify some code, enable use of `filter` on all outputs, new `cite` decorator, new `show` for when ads is not installed or the user is offline.  Complete testing coverage for all code independent of `ads`.