### PR TITLE
New quantity_to_dataclass decorator.

### DIFF
--- a/sbpy/data/__init__.py
+++ b/sbpy/data/__init__.py
@@ -239,10 +239,10 @@ class Conf():
          'fieldnames': ['totnum', 'total_number_nocd'],
          'provenance': ['phys'],
          'dimension': None},
-         {'description': 'Column Density from Bockelee Morvan et al. 2004',
-          'fieldnames': ['cdensity', 'col_density'],
-          'provenance': ['phys'],
-          'dimension': '1/length^2'},
+        {'description': 'Column Density from Bockelee Morvan et al. 2004',
+         'fieldnames': ['cdensity', 'col_density'],
+         'provenance': ['phys'],
+         'dimension': '1/length^2'},
         # {'description': '',
         #  'fieldnames': [],
         #  'provenance': [],
@@ -306,7 +306,7 @@ class Conf():
 
 conf = Conf()
 
-from .core import DataClass, DataClassError
+from .core import DataClass, DataClassError, quantity_to_dataclass
 from .ephem import Ephem
 from .orbit import Orbit
 from .phys import Phys

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -7,6 +7,8 @@ sbpy.data core module
 created on June 22, 2017
 """
 
+import inspect
+from functools import wraps
 from copy import deepcopy
 from collections import OrderedDict
 from numpy import ndarray, array, hstack
@@ -16,7 +18,7 @@ import astropy.units as u
 from . import conf
 from .. import exceptions
 
-__all__ = ['DataClass', 'DataClassError']
+__all__ = ['DataClass', 'DataClassError', 'quantity_to_dataclass']
 
 
 class DataClassError(exceptions.SbpyException):
@@ -824,3 +826,74 @@ class DataClass():
         _newtable.add_column(Column(_newcolumn, name=name, unit=unit))
 
         self._table = _newtable
+
+
+def quantity_to_dataclass(parameter, field, dataclass):
+    """Decorator that converts astropy quantities to sbpy data classes.
+
+
+    Parameters
+    ----------
+    parameter : string
+        Function parameter name (``DataClass``) that the quantity
+        input will be converted to.
+
+    field : string
+        Name of the field the quantity corresponds to.
+
+    dataclass : DataClass
+        Object that will hold the field.
+
+
+    Returns
+    -------
+    decorator : function
+        Function decorator.
+
+
+    Examples
+    --------
+    >>> import astropy.units as u
+    >>> @quantity_to_dataclass('eph', 'rh', Ephem)
+    ... def temperature(eph):
+    ...     return 278 * u.K / (eph['rh'] / u.au)**0.5
+    >>> print(temperature(1 * u.au))
+    278.0 K
+    >>> print(temperature(Ephem.from_dict({'rh': 1 * u.au})))
+    278.0 K
+
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+
+            # In case of multiple decorators, find the original
+            # wrapped function
+            f = func
+            while True:
+                try:
+                    f = getattr(f, '__wrapped__')
+                except AttributeError:
+                    break
+            argspec = inspect.getfullargspec(f)
+
+            if parameter not in argspec.args:
+                raise ValueError('Parameter {} not in {} argument list'
+                                 .format(parameter, f.__qualname__))
+
+            new_args = []  # args, but with replaced parameter
+            for name, value in zip(argspec.args, args):
+                # find argument name matching parameter
+                if name != parameter:
+                    new_args.append(value)
+                elif isinstance(value, DataClass):
+                    new_args.append(value)
+                else:
+                    # create DataClass object
+                    data = dataclass.from_dict({field: value})
+                    new_args.append(data)
+
+            return func(*new_args, **kwargs)
+        return wrapper
+    return decorator

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -854,13 +854,16 @@ def quantity_to_dataclass(parameter, field, dataclass):
     Examples
     --------
     >>> import astropy.units as u
+    >>> from sbpy.data import quantity_to_dataclass, Ephem
     >>> @quantity_to_dataclass('eph', 'rh', Ephem)
     ... def temperature(eph):
     ...     return 278 * u.K / (eph['rh'] / u.au)**0.5
-    >>> print(temperature(1 * u.au))
-    278.0 K
-    >>> print(temperature(Ephem.from_dict({'rh': 1 * u.au})))
-    278.0 K
+    >>> print(temperature(1 * u.au))    # doctest: +FLOAT_CMP
+    [278.] K
+    >>> print(temperature(
+    ...     Ephem.from_dict({'rh': 1 * u.au})
+    ... ))                              # doctest: +FLOAT_CMP
+    [278.] K
 
     """
 
@@ -888,6 +891,7 @@ def quantity_to_dataclass(parameter, field, dataclass):
                 if name != parameter:
                     new_args.append(value)
                 elif isinstance(value, DataClass):
+                    # already a DataClass
                     new_args.append(value)
                 else:
                     # create DataClass object

--- a/sbpy/data/tests/test_decorator.py
+++ b/sbpy/data/tests/test_decorator.py
@@ -1,0 +1,40 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+import astropy.units as u
+from .. import quantity_to_dataclass, Ephem, Orbit, Phys
+
+
+def test_quantity_to_dataclass_single():
+    @quantity_to_dataclass('eph', 'rh', Ephem)
+    def temperature(eph):
+        return 278 * u.K / np.sqrt(eph['rh'] / u.au)
+
+    rh = 1 * u.au
+    eph = Ephem.from_dict({'rh': 1 * u.au})
+    assert temperature(rh) == temperature(eph)
+    assert np.isclose(temperature(rh).value, 278.0)
+
+
+def test_quantity_to_dataclass_double():
+    @quantity_to_dataclass('eph', 'rh', Ephem)
+    @quantity_to_dataclass('orbit', 'a', Orbit)
+    def contrived(eph, orbit):
+        return (eph['rh'] / orbit['a']).decompose()
+
+    rh = 1 * u.au
+    a = 2 * u.au
+    assert np.isclose(contrived(rh, a).value, 0.5)
+
+
+def test_quantity_to_dataclass_triple():
+    @quantity_to_dataclass('eph', 'rh', Ephem)
+    @quantity_to_dataclass('orbit', 'a', Orbit)
+    @quantity_to_dataclass('phys', 'R', Phys)
+    def contrived(eph, orbit, phys):
+        return (eph['rh'] / orbit['a']).decompose() * phys['R']
+
+    rh = 1 * u.au
+    a = 2 * u.au
+    R = 100 * u.km
+    assert np.isclose(contrived(rh, a, R).value, 50)

--- a/sbpy/data/tests/test_decorator.py
+++ b/sbpy/data/tests/test_decorator.py
@@ -7,13 +7,13 @@ from .. import quantity_to_dataclass, Ephem, Orbit, Phys
 
 def test_quantity_to_dataclass_single():
     @quantity_to_dataclass('eph', 'rh', Ephem)
-    def temperature(eph):
+    def temperature(eph, a, b, c, d=5):
         return 278 * u.K / np.sqrt(eph['rh'] / u.au)
 
     rh = 1 * u.au
     eph = Ephem.from_dict({'rh': 1 * u.au})
-    assert temperature(rh) == temperature(eph)
-    assert np.isclose(temperature(rh).value, 278.0)
+    assert temperature(rh, 1, 2, 3) == temperature(eph, 7, 8, 9, d=10)
+    assert np.isclose(temperature(rh, 4, 5, 6).value, 278.0)
 
 
 def test_quantity_to_dataclass_double():


### PR DESCRIPTION
```python
>>> import astropy.units as u
>>> from sbpy.data import quantity_to_dataclass, Ephem
>>> @quantity_to_dataclass('eph', 'rh', Ephem)
... def temperature(eph):
...     return 278 * u.K / (eph['rh'] / u.au)**0.5
>>> print(temperature(1 * u.au))
[278.] K
>>> print(temperature(Ephem.from_dict({'rh': 1 * u.au})))
[278.] K
```

Tested up to three levels of decoration:

```python
@quantity_to_dataclass('eph', 'rh', Ephem)
@quantity_to_dataclass('orbit', 'a', Orbit)
@quantity_to_dataclass('phys', 'R', Phys)
def contrived(eph, orbit, phys):
    return (eph['rh'] / orbit['a']).decompose() * phys['R']
```