### PR TITLE
Projected size equivalencies

### DIFF
--- a/docs/sbpy/activity/index.rst
+++ b/docs/sbpy/activity/index.rst
@@ -40,7 +40,7 @@ Apertures may be converted between linear and angular units using :func:`~sbpy.a
 
   >>> ap = sba.CircularAperture(1 * u.arcsec)
   >>> ap.as_length(1 * u.au)  # doctest: +FLOAT_CMP
-  <CircularAperture: radius [725270.94380784] m>
+  <CircularAperture: radius [725.27094381] km>
 
 Ideal comae (constant production rate, free-expansion, infinite lifetime) have *1/ρ* surface brightness distributions.  With :func:`~sbpy.activity.Aperture.coma_equivalent_radius`, we may convert the aperture into a circular aperture that would contain the same total flux at the telescope:
 

--- a/docs/sbpy/units.rst
+++ b/docs/sbpy/units.rst
@@ -4,9 +4,7 @@ Units Module (`sbpy.units`)
 Introduction
 ------------
 
-`~sbpy.units` provides common planetary astronomy units and Vega-based
-magnitude conversions.  ``sbpy`` units may be added to the top-level
-``astropy.units`` namespace via:
+`~sbpy.units` provides common planetary astronomy units and unit conversions, including Vega-based magnitudes.  ``sbpy`` units may be added to the top-level ``astropy.units`` namespace via:
 
   >>> import sbpy.units
   >>> sbpy.units.enable()    # doctest: +IGNORE_OUTPUT
@@ -122,6 +120,21 @@ phase angle can be calculated:
   >>> ref = flux.to('1/sr', reflectance(wave, cross_section=xsec))
   >>> print(ref)  # doctest: +FLOAT_CMP
   [0.0021763  0.00201223 0.0022041  0.00269637 0.00292785] 1 / sr
+
+
+Projected Sizes
+---------------
+
+With the `~sbpy.units.projected_size` equivalencies, one may convert between angles and lengths, for a given distance:
+
+  >>> import astropy.units as u
+  >>> import sbpy.units as sbu
+  >>> (1 * u.arcsec).to('km', sbu.projected_size(1 * u.delta))
+  ... # doctest: +FLOAT_CMP
+  [725.27] km
+  >>> (725.27 * u.km).to('arcsec', sbu.projected_size(1 * u.delta))
+  ... # doctest: +FLOAT_CMP
+  [1.00] arcsec
 
 
 Reference/API

--- a/docs/sbpy/units.rst
+++ b/docs/sbpy/units.rst
@@ -129,12 +129,12 @@ With the `~sbpy.units.projected_size` equivalencies, one may convert between ang
 
   >>> import astropy.units as u
   >>> import sbpy.units as sbu
-  >>> (1 * u.arcsec).to('km', sbu.projected_size(1 * u.delta))
+  >>> (1 * u.arcsec).to('km', sbu.projected_size(1 * u.au))
   ... # doctest: +FLOAT_CMP
-  [725.27] km
-  >>> (725.27 * u.km).to('arcsec', sbu.projected_size(1 * u.delta))
+  <Quantity [725.27094381] km>
+  >>> (725.27 * u.km).to('arcsec', sbu.projected_size(1 * u.au))
   ... # doctest: +FLOAT_CMP
-  [1.00] arcsec
+  <Quantity [1.00] arcsec>
 
 
 Reference/API

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -26,8 +26,9 @@ from ..calib import Sun
 from ..spectroscopy import BlackbodySource
 from .. import data as sbd
 from .. import exceptions as sbe
+from .. import units as sbu
 from ..spectroscopy.sources import SinglePointSpectrumError
-from .core import Aperture, rho_as_length
+from .core import Aperture
 
 
 @bib.cite({
@@ -254,7 +255,7 @@ class DustComaQuantity(u.SpecificTypeQuantity, abc.ABC,
         else:
             rho = aper
             ndim = np.ndim(rho)
-        rho = rho_as_length(rho, eph)
+        rho = rho.to('km', sbu.projected_size(eph))
 
         ndim = max(ndim, np.ndim(self))
 

--- a/sbpy/activity/tests/test_core.py
+++ b/sbpy/activity/tests/test_core.py
@@ -3,44 +3,8 @@
 import pytest
 import numpy as np
 import astropy.units as u
+from ... import units as sbu
 from ..core import *
-
-
-def test_rho_as_angle_length():
-    # arctan(100 km, 1 au) * 206264.806 = 0.13787950659645942
-    rho = rho_as_angle(100 * u.km, {'delta': 1 * u.au})
-    assert np.isclose(rho.to(u.arcsec).value, 0.13787950659645942)
-
-
-def test_rho_as_angle_angle():
-    assert rho_as_angle(1 * u.rad, {'delta': 1 * u.au}).value == 1
-
-
-def test_rho_as_angle_error():
-    with pytest.raises(u.UnitConversionError):
-        rho_as_angle(1 * u.s, {'delta': 1 * u.au})
-
-
-def test_rho_as_length_angle():
-    # 1 au * tan(1") = 725.2709438078363
-    rho = rho_as_length(1 * u.arcsec, {'delta': 1 * u.au})
-    assert np.isclose(rho.to(u.km).value, 725.2709438078363)
-
-
-def test_rho_as_length_length():
-    assert rho_as_length(1 * u.km, {'delta': 1 * u.au}).value == 1
-
-
-def test_rho_as_length_error():
-    with pytest.raises(u.UnitConversionError):
-        rho_as_length(1 * u.s, {'delta': 1 * u.au})
-
-
-def test_rho_roundtrip():
-    a = 10 * u.arcsec
-    eph = {'delta': 1 * u.au}
-    b = rho_as_angle(rho_as_length(a, eph), eph)
-    assert np.isclose(a.value, b.to(u.arcsec).value)
 
 
 class TestCircularAperture:
@@ -61,13 +25,15 @@ class TestCircularAperture:
         r = 1 * u.arcsec
         aper = CircularAperture(r)
         eph = {'delta': 1 * u.au}
-        assert aper.as_length(eph).dim == rho_as_length(r, eph)
+        length = r.to('km', sbu.projected_size(eph))
+        assert np.isclose(aper.as_length(eph).dim.value, length.value)
 
     def test_as_angle(self):
         r = 100 * u.km
         aper = CircularAperture(r)
         eph = {'delta': 1 * u.au}
-        assert aper.as_angle(eph).dim == rho_as_angle(r, eph)
+        angle = r.to('arcsec', sbu.projected_size(eph))
+        assert np.isclose(aper.as_angle(eph).dim.value, angle.value)
 
 
 class TestAnnularAperture:
@@ -85,18 +51,6 @@ class TestAnnularAperture:
         aper = AnnularAperture(shape)
         assert aper.coma_equivalent_radius() == 1 * u.arcsec
 
-    def test_as_length(self):
-        shape = [1, 2] * u.arcsec
-        aper = AnnularAperture(shape)
-        eph = {'delta': 1 * u.au}
-        assert all(aper.as_length(eph).dim == rho_as_length(shape, eph))
-
-    def test_as_angle(self):
-        shape = [100, 200] * u.km
-        aper = AnnularAperture(shape)
-        eph = {'delta': 1 * u.au}
-        assert all(aper.as_angle(eph).dim == rho_as_angle(shape, eph))
-
     def test_shape_error(self):
         with pytest.raises(ValueError):
             AnnularAperture([1, 2, 3] * u.km)
@@ -112,18 +66,6 @@ class TestRectangularAperture:
         aper = RectangularAperture(shape)
         r = aper.coma_equivalent_radius()
         assert np.isclose(r.value, 0.66776816346357259)
-
-    def test_as_length(self):
-        shape = [1, 2] * u.arcsec
-        aper = RectangularAperture(shape)
-        eph = {'delta': 1 * u.au}
-        assert all(aper.as_length(eph).dim == rho_as_length(shape, eph))
-
-    def test_as_angle(self):
-        shape = [100, 200] * u.km
-        aper = RectangularAperture(shape)
-        eph = {'delta': 1 * u.au}
-        assert all(aper.as_angle(eph).dim == rho_as_angle(shape, eph))
 
     def test_shape_error(self):
         with pytest.raises(ValueError):
@@ -148,18 +90,6 @@ class TestGaussianAperture:
         sigma = 1 * u.arcsec
         aper = GaussianAperture(sigma)
         assert aper.coma_equivalent_radius() == np.sqrt(np.pi / 2) * u.arcsec
-
-    def test_as_length(self):
-        sig = 1 * u.arcsec
-        aper = GaussianAperture(sig)
-        eph = {'delta': 1 * u.au}
-        assert aper.as_length(eph).dim == rho_as_length(sig, eph)
-
-    def test_as_angle(self):
-        sig = 100 * u.km
-        aper = GaussianAperture(sig)
-        eph = {'delta': 1 * u.au}
-        assert aper.as_angle(eph).dim == rho_as_angle(sig, eph)
 
     def test_call_angle(self):
         aper = GaussianAperture(1 * u.arcsec)

--- a/sbpy/units/core.py
+++ b/sbpy/units/core.py
@@ -298,12 +298,12 @@ def projected_size(eph: sbd.Ephem):
     --------
     >>> import astropy.units as u
     >>> import sbpy.units as sbu
-    >>> (1 * u.arcsec).to('km', sbu.projected_size(1 * u.delta))
+    >>> (1 * u.arcsec).to('km', sbu.projected_size(1 * u.au))
     ... # doctest: +FLOAT_CMP
-    [725.27] km
-    >>> (725.27 * u.km).to('arcsec', sbu.projected_size(1 * u.delta))
+    <Quantity [725.27094381] km>
+    >>> (725.27 * u.km).to('arcsec', sbu.projected_size(1 * u.au))
     ... # doctest: +FLOAT_CMP
-    [1.00] arcsec
+    <Quantity [1.00] arcsec>
 
     """
 

--- a/sbpy/units/tests/test_core.py
+++ b/sbpy/units/tests/test_core.py
@@ -204,3 +204,13 @@ def test_reflectance_spec():
     for ref in (ref1, ref2, ref3):
         assert ref.unit == '1/sr'
         assert np.allclose(ref.value, t1['ref'])
+
+
+@pytest.mark.parametrize('value, delta, test', (
+    (1 * u.arcsec, 1 * u.au, np.tan(1 * u.arcsec) * u.au),
+    (725.27 * u.km, 1 * u.au, np.tan(1 * u.arcsec) * u.rad),
+))
+def test_projected_size(value, delta, test):
+    test = test.decompose()
+    result = value.to(test.unit, projected_size(delta))
+    assert np.isclose(result.value, test.value)


### PR DESCRIPTION
Replacing `activity.rho_as_length` and `activity.rho_as_angle` with `units.projected_size`:

```python
>>> import astropy.units as u
>>> import sbpy.units as sbu
>>> (1 * u.arcsec).to('km', sbu.projected_size(1 * u.au))
<Quantity [725.27094381] km>
>>> (725.27 * u.km).to('arcsec', sbu.projected_size(1 * u.au))
<Quantity [1.00] arcsec>
```

Also works with `Ephem` objects.