### PR TITLE
Allow unit check for decorator quantity_to_dataclass

### DIFF
--- a/sbpy/data/decorators.py
+++ b/sbpy/data/decorators.py
@@ -93,7 +93,8 @@ def quantity_to_dataclass(**kwargs):
                     from astropy.units.decorators import (_get_allowed_units,
                          _validate_arg_value)
                     units = decorator_kwargs[param.name][2]
-                    if not hasattr(units, '__iter__'):
+                    if isinstance(units, str) or (not hasattr(units,
+                            '__iter__')):
                         units = [units]
                     units = _get_allowed_units(units)
                 else:

--- a/sbpy/data/decorators.py
+++ b/sbpy/data/decorators.py
@@ -110,7 +110,7 @@ def quantity_to_dataclass(**kwargs):
                         " object".format(param.name, wrapped_function.__name__,
                         field, dataclass))
                 units = [x['dimension'] for x in [Conf.fieldnames_info[i] for
-                    i,x in enumerate(field_idx) if x]]
+                    i, x in enumerate(field_idx) if x]]
                 if isinstance(units, str) or (not hasattr(units, '__iter__')):
                     units = [units]
                 for i in range(len(units)):
@@ -131,7 +131,7 @@ def quantity_to_dataclass(**kwargs):
                         units[i] = 'sr'
                         equivalencies.extend(u.dimensionless_angles())
                     elif units[i] == 'intensity':
-                        units[i] = 'W/(m**2 sr)' # is this correct?
+                        units[i] = 'W/(m**2 sr)'   # is this correct?
                     elif units[i] == '1/time':
                         units[i] = '1/s'
                     elif units[i] == 'time * length^2':

--- a/sbpy/data/decorators.py
+++ b/sbpy/data/decorators.py
@@ -42,6 +42,19 @@ def quantity_to_dataclass(**kwargs):
     >>> print(temperature(eph))         # doctest: +FLOAT_CMP
     [278.] K
 
+    This decorator also optionally check function parameters as
+    astropy Quantity and units similar to the functionality of
+    `astropy.units.quantity_input`:
+
+    >>> import astropy.units as u
+    >>> import sbpy.data as sbd
+    >>>
+    >>> @sbd.quantity_to_dataclass(eph=(sbd.Ephem, 'rh', 'length'))
+    ... def temperature(eph):
+    ...     return 278 * u.K / (eph['rh'] / u.au)**0.5
+    >>>
+    >>> print(temperature(1 * u.s))     # doctest: +SKIP
+    UnitsError: Argument 'eph' to function 'temperature' must be in units convertible to 'm'.
     """
 
     def decorator(wrapped_function):

--- a/sbpy/data/decorators.py
+++ b/sbpy/data/decorators.py
@@ -13,8 +13,9 @@ __all__ = [
 import inspect
 from functools import wraps
 from astropy.table import Table, QTable
+from astropy.time import Time
 import astropy.units as u
-from .core import DataClass
+from .core import DataClass, DataClassError
 from . import Conf
 
 
@@ -47,11 +48,16 @@ def quantity_to_dataclass(**kwargs):
     This decorator also validates the dimensions of function parameters
     against the default dimensions as listed in the Field Name List
     (https://sbpy.readthedocs.io/en/latest/sbpy/data/fieldnames.html#id1).
+    Users can provide equivalencies through an optional parameter
+    `equivalencies=` to be used in unit checking.  Equivalencies for
+    dimensionless angle and temperature are automatically enabled.
+
     A `~astropy.units.UnitsError` will be raised if the unit attribute of the
-    argument is not equivalent to default unit.  If the default dimension is
+    argument is not equivalent to default unit.    If the default dimension is
     not `None`, and the argument has no unit attribute, and  i.e. it is not a
     Quantity object, a `ValueError` will be raised.
     """
+    equivalencies = kwargs.pop('equivalencies', [])
 
     def decorator(wrapped_function):
         decorator_kwargs = kwargs  # for clarity
@@ -99,23 +105,64 @@ def quantity_to_dataclass(**kwargs):
 
                 field_idx = [field in x for x in Conf.fieldnames]
                 if not any(field_idx):
-                    raise DataClassError('argument {} to function {} has an'
-                        ' invalide field name {} for {}'
-                        ' object'.format(param.name, wrapped_function.__name__,
+                    raise DataClassError("argument '{}' to function '{}' has"
+                        " an invalide field name '{}' for {}"
+                        " object".format(param.name, wrapped_function.__name__,
                         field, dataclass))
                 units = [x['dimension'] for x in [Conf.fieldnames_info[i] for
                     i,x in enumerate(field_idx) if x]]
                 if isinstance(units, str) or (not hasattr(units, '__iter__')):
                     units = [units]
-                equivlencies = []
                 for i in range(len(units)):
                     # translate the dimension as listed in sbpy Field Name List
                     # to astropy-recoganizable unit strings
                     if units[i] is None:
                         units[i] = ''
+                    elif units[i] in ['angle', 'deg']:
+                        equivalencies.extend(u.dimensionless_angles())
+                    elif units[i] == 'angular velocity':
+                        units[i] = '1/s'
+                        equivalencies.extend(u.dimensionless_angles())
+                    elif units[i] == 'velocity':
+                        units[i] = 'm/s'
+                    elif units[i] == 'magnitude':
+                        units[i] = 'mag'
+                    elif units[i] == 'angular area':
+                        units[i] = 'sr'
+                        equivalencies.extend(u.dimensionless_angles())
+                    elif units[i] == 'intensity':
+                        units[i] = 'W/(m**2 sr)' # is this correct?
+                    elif units[i] == '1/time':
+                        units[i] = '1/s'
+                    elif units[i] == 'time * length^2':
+                        units[i] = 's * m**2'
+                    elif units[i] == '1/length^2':
+                        units[i] = '1/m**2'
+                    elif units[i] == 'temperature':
+                        equivalencies.extend(u.temperature())
                 if any([x == '' for x in units]):
+                    # dimensionless unit
                     if not hasattr(arg, 'unit'):
                         arg = arg * u.dimensionless_unscaled
+                if any([x == '`~astropy.time.Time`' for x in units]):
+                    # astropy.time.Time type
+                    units = []
+                    raiseError = False
+                    if isinstance(arg, Time):
+                        pass
+                    else:
+                        try:
+                            if all([isinstance(x, Time) for x in arg]):
+                                pass
+                            else:
+                                raiseError = True
+                        except TypeError:
+                            raiseError = True
+                    if raiseError:
+                        raise TypeError("Argument '{}' to function '{}' must"
+                            " be a `~astropy.time.Time` instance or an array"
+                            " thereof".format(param.name,
+                                wrapped_function.__name__))
 
                 from astropy.units.decorators import (_get_allowed_units,
                      _validate_arg_value)
@@ -125,7 +172,8 @@ def quantity_to_dataclass(**kwargs):
                     # Argument is not a DataClass.  Make it so.
                     if units:
                         _validate_arg_value(param.name,
-                            wrapped_function.__name__, arg, units, [])
+                            wrapped_function.__name__, arg, units,
+                            equivalencies)
                     new_arg = dataclass.from_dict({field: arg})
                     bound_args.arguments[param.name] = new_arg
 

--- a/sbpy/data/tests/test_decorators.py
+++ b/sbpy/data/tests/test_decorators.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 import astropy.units as u
 from astropy.table import Table, QTable
+from astropy.time import Time
 import pytest
 from ... import data as sbd
 from ..decorators import *
@@ -54,6 +55,85 @@ def test_quantity_to_dataclass_stacked():
         contrived(1, a, R)
     with pytest.raises(u.UnitsError):
         contrived(rh, 2 * u.s, R)
+
+
+u.imperial.enable()
+@pytest.mark.parametrize('field, arg, test_unit', (
+    ('a', 1 * u.au, 's'),
+    ('e', 0.5, 's'),
+    ('inc', 10 * u.deg, 's'),
+    ('delta_v', 0.5 * u.km/u.s, 'm'),
+    ('P', 9. * u.hour, 'm'),
+    ('ra_rate', 10 * u.rad / u.day, 's'),
+    ('V', 3 * u.mag, 'm'),
+    ('lun_illum', 10 * u.percent, 'm'),
+    ('area_3sigma', 10 * u.deg**2, 'm'),
+    ('area_3sigma', 10 * u.sr, 'm'),
+    ('sband_3sigma', 5 * u.GHz, 's'),
+    ('temp', 300 * u.K, 'm'),  # looks like astropy has problem handling
+    # temperature units
+    ('lgint300', 300 * u.Unit('W/(m**2 sr)'), 'm/s'),
+    ('eup_j', 1 * u.J, 'm'),
+    ('eup_j', 1 * u.eV, 'm')
+))
+def test_quantity_to_dataclass_dimensions(field, arg, test_unit):
+    @quantity_to_dataclass(x=(field, sbd.DataClass))
+    def test(x):
+        return x[field]
+
+    assert all(test(arg) == arg)
+    if isinstance(arg, u.Quantity):
+        with pytest.raises((TypeError, AttributeError)):
+            test(1)
+    with pytest.raises(u.UnitsError):
+        test(1 * u.Unit(test_unit))
+
+
+@pytest.mark.parametrize('arg, test_arg', (
+    (Time('2019-01-01'), Time('2019-01-01')),
+    (Time(['2019-01-01', '2019-01-02']), Time(['2019-01-01', '2019-01-02'])),
+    ([Time('2019-01-01'), Time('2019-01-02')], Time(['2019-01-01', '2019-01-02']))
+))
+def test_quantity_to_dataclass_timetype(arg, test_arg):
+    @quantity_to_dataclass(x=('epoch', sbd.Obs))
+    def test(x):
+        return x['epoch']
+
+    assert np.all(test(arg) == test_arg)
+
+
+@pytest.mark.parametrize('arg', (
+    (1),
+    ('2015-01-01'),
+    (1 * u.s),
+    ([1, 2]),
+    ([1, 2] * u.s)
+))
+def test_quantity_to_dataclass_timetype_error(arg):
+    @quantity_to_dataclass(x=('epoch', sbd.Obs))
+    def test(x):
+        return x['epoch']
+
+    with pytest.raises(TypeError):
+        test(arg)
+
+
+def test_quantity_to_dataclass_equivalencies():
+    @quantity_to_dataclass(x=('sband_3sigma', sbd.Obs), equivalencies=u.spectral())
+    def test(x):
+        return x['sband_3sigma']
+
+    assert test(1 * u.mm) == (1 * u.mm)
+    assert test(300 * u.GHz) == (300 * u.GHz)
+
+
+def test_quantity_to_dataclass_dataclasserror():
+    @quantity_to_dataclass(x=('test', sbd.Obs))
+    def test(x):
+        return x['test']
+
+    with pytest.raises(sbd.DataClassError):
+        test(1)
 
 
 def test_quantity_to_dataclass_optional():

--- a/sbpy/data/tests/test_decorators.py
+++ b/sbpy/data/tests/test_decorators.py
@@ -18,17 +18,6 @@ def test_quantity_to_dataclass_single():
     eph = sbd.Ephem.from_dict({'rh': 1 * u.au})
     assert temperature(rh, 1, 2, 3) == temperature(eph, 7, 8, 9, d=10)
     assert np.isclose(temperature(rh, 4, 5, 6).value, 278.0)
-
-
-def test_quantity_to_dataclass_single_quantity_check():
-    @quantity_to_dataclass(eph=('rh', sbd.Ephem, 'length'))
-    def temperature(eph, a, b, c, d=5):
-        return 278 * u.K / np.sqrt(eph['rh'] / u.au)
-
-    rh = 1 * u.au
-    eph = sbd.Ephem.from_dict({'rh': 1 * u.au})
-    assert temperature(rh, 1, 2, 3) == temperature(eph, 7, 8, 9, d=10)
-    assert np.isclose(temperature(rh, 4, 5, 6).value, 278.0)
     with pytest.raises(TypeError):
         temperature(1, 1, 2, 3)
     with pytest.raises(u.UnitsError):
@@ -37,17 +26,6 @@ def test_quantity_to_dataclass_single_quantity_check():
 
 def test_quantity_to_dataclass_multiple():
     @quantity_to_dataclass(eph=('rh', sbd.Ephem), orbit=('a', sbd.Orbit))
-    def contrived(eph, orbit):
-        return (eph['rh'] / orbit['a']).decompose()
-
-    rh = 1 * u.au
-    a = 2 * u.au
-    assert np.isclose(contrived(rh, a).value, 0.5)
-
-
-def test_quantity_to_dataclass_multiple_quantity_check():
-    @quantity_to_dataclass(eph=('rh', sbd.Ephem, 'length'),
-        orbit=('a', sbd.Orbit, 'length'))
     def contrived(eph, orbit):
         return (eph['rh'] / orbit['a']).decompose()
 
@@ -65,20 +43,6 @@ def test_quantity_to_dataclass_stacked():
     @quantity_to_dataclass(eph=('rh', sbd.Ephem))
     @quantity_to_dataclass(orbit=('a', sbd.Orbit))
     @quantity_to_dataclass(phys=('R', sbd.Phys))
-    def contrived(eph, orbit, phys):
-        return (eph['rh'] / orbit['a']).decompose() * phys['R']
-
-    rh = 1 * u.au
-    a = 2 * u.au
-    R = 100 * u.km
-    assert np.isclose(contrived(rh, a, R).value, 50)
-
-
-def test_quantity_to_dataclass_stacked_quantity_check():
-    """Note, this is not a preferred use case."""
-    @quantity_to_dataclass(eph=('rh', sbd.Ephem, 'length'))
-    @quantity_to_dataclass(orbit=('a', sbd.Orbit, 'au'))
-    @quantity_to_dataclass(phys=('R', sbd.Phys, 'km'))
     def contrived(eph, orbit, phys):
         return (eph['rh'] / orbit['a']).decompose() * phys['R']
 

--- a/sbpy/data/tests/test_decorators.py
+++ b/sbpy/data/tests/test_decorators.py
@@ -58,6 +58,8 @@ def test_quantity_to_dataclass_stacked():
 
 
 u.imperial.enable()
+
+
 @pytest.mark.parametrize('field, arg, test_unit', (
     ('a', 1 * u.au, 's'),
     ('e', 0.5, 's'),

--- a/sbpy/data/tests/test_decorators.py
+++ b/sbpy/data/tests/test_decorators.py
@@ -19,6 +19,7 @@ def test_quantity_to_dataclass_single():
     assert temperature(rh, 1, 2, 3) == temperature(eph, 7, 8, 9, d=10)
     assert np.isclose(temperature(rh, 4, 5, 6).value, 278.0)
 
+
 def test_quantity_to_dataclass_single_quantity_check():
     @quantity_to_dataclass(eph=('rh', sbd.Ephem, 'length'))
     def temperature(eph, a, b, c, d=5):
@@ -33,6 +34,7 @@ def test_quantity_to_dataclass_single_quantity_check():
     with pytest.raises(u.UnitsError):
         temperature(1 * u.s, 1, 2, 3)
 
+
 def test_quantity_to_dataclass_multiple():
     @quantity_to_dataclass(eph=('rh', sbd.Ephem), orbit=('a', sbd.Orbit))
     def contrived(eph, orbit):
@@ -41,6 +43,7 @@ def test_quantity_to_dataclass_multiple():
     rh = 1 * u.au
     a = 2 * u.au
     assert np.isclose(contrived(rh, a).value, 0.5)
+
 
 def test_quantity_to_dataclass_multiple_quantity_check():
     @quantity_to_dataclass(eph=('rh', sbd.Ephem, 'length'),
@@ -56,6 +59,7 @@ def test_quantity_to_dataclass_multiple_quantity_check():
     with pytest.raises(u.UnitsError):
         contrived(rh, 2 * u.s)
 
+
 def test_quantity_to_dataclass_stacked():
     """Note, this is not a preferred use case."""
     @quantity_to_dataclass(eph=('rh', sbd.Ephem))
@@ -68,6 +72,7 @@ def test_quantity_to_dataclass_stacked():
     a = 2 * u.au
     R = 100 * u.km
     assert np.isclose(contrived(rh, a, R).value, 50)
+
 
 def test_quantity_to_dataclass_stacked_quantity_check():
     """Note, this is not a preferred use case."""
@@ -85,6 +90,7 @@ def test_quantity_to_dataclass_stacked_quantity_check():
         contrived(1, a, R)
     with pytest.raises(u.UnitsError):
         contrived(rh, 2 * u.s, R)
+
 
 def test_quantity_to_dataclass_optional():
     @quantity_to_dataclass(eph=('rh', sbd.Ephem))

--- a/sbpy/photometry/tests/test_core.py
+++ b/sbpy/photometry/tests/test_core.py
@@ -27,52 +27,25 @@ def test_mag2ref():
 
 class TestLinear():
     def test_init(self):
-        linphase = LinearPhaseFunc(5, 2.29, radius=300)
+        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg, radius=300)
         assert np.isclose(linphase.H.value, 5)
-        assert np.isclose(linphase.S.value, 2.29)
+        assert linphase.H.unit == u.mag
+        assert np.isclose(linphase.S.value, 0.04)
+        assert linphase.S.unit == u.mag/u.deg
 
     def test_mag(self):
-        linphase = LinearPhaseFunc(5, 2.29, radius=300)
-        pha_test = np.linspace(0, np.pi, 10)
-        mag_test = np.array(
-            [5.0, 5.799360797413403, 6.598721594826806,
-             7.398082392240209, 8.197443189653612, 8.996803987067015,
-             9.796164784480418, 10.59552558189382, 11.394886379307223,
-             12.194247176720626])
-        eph = linphase.to_mag(pha_test, append_results=True)
-        assert np.isclose(eph['mag'], mag_test).all()
-        assert np.isclose(eph['alpha'], pha_test).all()
-        assert set(eph.field_names) == {'alpha', 'mag'}
-
         linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg, radius=300)
-        pha_test = np.linspace(0, 180, 10) * u.deg
+        pha_test = np.linspace(0, np.pi, 10) * u.rad
+        mag_test = np.array([5., 5.8, 6.6, 7.4, 8.2, 9., 9.8, 10.6, 11.4,
+            12.2]) * u.mag
         eph = linphase.to_mag(pha_test, append_results=True)
-        mag_test = np.array([5., 5.8, 6.6, 7.4, 8.2, 9., 9.8, 10.6, 11.4, 12.2])*u.mag
-        if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph['mag'], mag_test).all()
-            assert u.isclose(eph['alpha'], pha_test).all()
+        assert np.allclose(eph['mag'].value, mag_test.value)
+        assert eph['mag'].unit == mag_test.unit
+        assert np.allclose(eph['alpha'].value, pha_test.value)
+        assert eph['alpha'].unit == pha_test.unit
         assert set(eph.field_names) == {'alpha', 'mag'}
 
     def test_ref(self):
-        linphase = LinearPhaseFunc(5, 2.29, radius=300)
-        pha_test = np.linspace(0, np.pi, 10)
-        ref_test = np.array(
-            [1.59389035e-02, 7.63333149e-03, 3.65569373e-03,
-             1.75075544e-03, 8.38457717e-04, 4.01547427e-04, 1.92305864e-04,
-             9.20975780e-05, 4.41066314e-05, 2.11231932e-05])
-        ref_norm_test = np.array(
-            [1., 0.47891196, 0.22935666,
-             0.10984165, 0.05260448, 0.02519291, 0.01206519, 0.00577816,
-             0.00276723, 0.00132526])
-        eph = linphase.to_ref(pha_test, append_results=True)
-        assert np.isclose(eph['ref'], ref_test).all()
-        assert np.isclose(eph['alpha'], pha_test).all()
-        assert set(eph.field_names) == {'alpha', 'ref'}
-        eph_norm = linphase.to_ref(pha_test, normalized=0, append_results=True)
-        assert np.isclose(eph_norm['ref'], ref_norm_test).all()
-        assert np.isclose(eph_norm['alpha'], pha_test).all()
-        assert set(eph_norm.field_names) == {'alpha', 'ref'}
-
         linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg, radius=300)
         pha_test = np.linspace(0, 180, 10) * u.deg
         eph = linphase.to_ref(pha_test, append_results=True)
@@ -85,17 +58,17 @@ class TestLinear():
              0.02511886, 0.01202264, 0.0057544, 0.00275423,
              0.00131826]) * u.dimensionless_unscaled
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph['ref'], ref_test).all()
-            assert u.isclose(eph['alpha'], pha_test).all()
+            assert u.allclose(eph['ref'], ref_test)
+            assert u.allclose(eph['alpha'], pha_test)
         assert set(eph.field_names) == {'alpha', 'ref'}
         eph_norm = linphase.to_ref(pha_test, normalized=0*u.deg, append_results=True)
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph_norm['ref'], ref_norm_test).all()
-            assert u.isclose(eph_norm['alpha'], pha_test).all()
+            assert u.allclose(eph_norm['ref'], ref_norm_test)
+            assert u.allclose(eph_norm['alpha'], pha_test)
         assert set(eph_norm.field_names) == {'alpha', 'ref'}
 
     def test_props(self):
-        linphase = LinearPhaseFunc(5, 2.29, radius=300)
+        linphase = LinearPhaseFunc(5 * u.mag, 2.29 * u.mag/u.rad, radius=300)
         assert np.isclose(linphase.geomalb, 0.05007354222252798)
         assert np.isclose(linphase.bondalb, 0.018404727835791654)
         assert np.isclose(linphase.phaseint, 0.3675539420399024)
@@ -105,12 +78,12 @@ class TestLinear():
         delta = [0.3, 1, 1, 2]
         m = LinearPhaseFunc(5*u.mag, 0.04*u.mag/u.deg)
         module = np.array([4.1195437, -0., -0.39590623, -3.01029996])
-        assert np.isclose(m._distance_module(
-            Ephem.from_dict({'r': r, 'delta': delta})), module).all()
+        assert np.allclose(m._distance_module(
+            Ephem.from_dict({'r': r, 'delta': delta})), module)
         m = HG(5*u.mag, 0.3*u.dimensionless_unscaled)
         module = np.array([4.1195437, -0., -0.39590623, -3.01029996])
-        assert np.isclose(m._distance_module(
-            Ephem.from_dict({'r': r, 'delta': delta})), module).all()
+        assert np.allclose(m._distance_module(
+            Ephem.from_dict({'r': r, 'delta': delta})), module)
 
 
 class TestHG:
@@ -165,7 +138,7 @@ class TestHG:
             [3.34, 4.37957695, 4.97935011,
              5.55797517, 6.20811269, 7.03560828, 8.2295693, 10.19445176,
              14.29255427, np.inf])
-        assert np.isclose(HG.evaluate(pha_test, 3.34, 0.12), phi_test).all()
+        assert np.allclose(HG.evaluate(pha_test, 3.34, 0.12), phi_test)
 
     def test_fit_deriv(self):
         pha_test = np.linspace(0, np.pi*0.999, 10)
@@ -174,8 +147,8 @@ class TestHG:
              [0., -1.33897222, -2.00745805, -2.43171634, -2.6155218,
               -2.46808816, -1.71295215, 0.06121683, 1.22716693,
               1.23379114]])
-        assert np.isclose(np.array(HG.fit_deriv(
-            pha_test, 3.34, 0.12)), deriv_test).all()
+        assert np.allclose(np.array(HG.fit_deriv(pha_test, 3.34, 0.12)),
+            deriv_test)
 
     def test__check_unit(self):
         ceres = HG(3.34, 0.12, radius=480*u.km, M_sun=-26.74)
@@ -246,31 +219,6 @@ class TestHG:
         assert m.meta['fields'] == ['mag', 'mag1', 'mag2']
 
     def test_to_mag(self):
-        ceres = HG(3.34, 0.12, radius=480)
-        eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10),
-                    'r': np.repeat(2.7*u.au, 10),
-                    'delta': np.repeat(1.8*u.au, 10)}
-        eph_test = Ephem.from_dict(eph_dict)
-        mag1_test = np.array(
-            [6.773181346311468, 7.746327508868813, 8.297741273359549,
-             8.813984838536113, 9.366879943505342, 10.024055427421063,
-             10.886692329621765, 12.143261499943726, 14.18326309145893,
-             18.48388800989832])
-        eph1 = ceres.to_mag(eph_test, append_results=True)
-        assert set(eph1.field_names) == {'alpha', 'delta', 'mag', 'r'}
-        assert np.isclose(eph1['mag'], mag1_test).all()
-        pha_test = np.linspace(0, np.pi*0.9, 10)
-        mag2_test = np.array(
-            [3.34, 4.313146162557345, 4.864559927048081, 5.380803492224645,
-             5.9336985971938745, 6.590874081109595, 7.453510983310297,
-             8.710080153632259, 10.750081745147462, 15.050706663586855])
-        eph3 = ceres.to_mag(pha_test, append_results=True)
-        assert np.isclose(eph3['mag'], mag2_test).all()
-        assert set(eph3.field_names) == {'alpha', 'mag'}
-        eph4 = ceres.to_mag(eph3, append_results=True)
-        assert set(eph4.field_names) == {'alpha', 'mag', 'mag1'}
-        assert np.isclose(eph4['mag'], eph4['mag1']).all()
-
         ceres = HG(3.34 * u.mag, 0.12 * u.dimensionless_unscaled, radius=480)
         eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10)*u.rad,
                     'r': np.repeat(2.7*u.au, 10),
@@ -284,8 +232,8 @@ class TestHG:
         eph1 = ceres.to_mag(eph_test, append_results=True)
         assert set(eph1.field_names) == {'alpha', 'delta', 'mag', 'r'}
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph1['mag'], mag1_test).all()
-        pha_test = np.linspace(0, np.pi*0.9, 10)
+            assert u.allclose(eph1['mag'], mag1_test)
+        pha_test = np.linspace(0, np.pi*0.9, 10) * u.rad
         mag2_test = np.array(
             [3.34, 4.313146162557345, 4.864559927048081, 5.380803492224645,
              5.9336985971938745, 6.590874081109595, 7.453510983310297,
@@ -293,44 +241,14 @@ class TestHG:
              15.050706663586855]) * u.mag
         eph3 = ceres.to_mag(pha_test, append_results=True)
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph3['mag'], mag2_test).all()
+            assert u.allclose(eph3['mag'], mag2_test)
         assert set(eph3.field_names) == {'alpha', 'mag'}
+        mag4 = ceres.to_mag(pha_test)
+        if LooseVersion(astropy.__version__) >= req_ver:
+            assert u.allclose(mag4, mag2_test)
 
     def test_ref(self):
-        ceres = HG(3.34, 0.12, radius=480)
-        eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10),
-                    'r': np.repeat(2.7*u.au, 10),
-                    'delta': np.repeat(1.8*u.au, 10)}
-        eph_test = Ephem.from_dict(eph_dict)
-        ref1_test = np.array(
-            [0.02872225123287084, 0.0117208743870569, 0.007053334911678305,
-             0.004384267859347806, 0.0026347477224558857,
-             0.0014383641304522461, 0.0006498514365555728,
-             0.0002042614521939071, 3.1202240400267656e-05,
-             5.942043286373853e-07])
-        eph1 = ceres.to_ref(eph_test, append_results=True)
-        assert set(eph1.field_names) == {'alpha', 'delta', 'ref', 'r'}
-        assert np.isclose(eph1['ref'], ref1_test).all()
-        pha_test = np.linspace(0, np.pi*0.9, 10)
-        ref2_test = np.array(
-            [2.87222512e-02, 1.17208744e-02, 7.05333491e-03, 4.38426786e-03,
-             2.63474772e-03, 1.43836413e-03, 6.49851437e-04, 2.04261452e-04,
-             3.12022404e-05, 5.94204329e-07])
-        ref2_norm_test = np.array(
-            [1.00000000e+00, 4.08076452e-01, 2.45570407e-01, 1.52643601e-01,
-             9.17319364e-02, 5.00783911e-02, 2.26253657e-02, 7.11161011e-03,
-             1.08634383e-03, 2.06879441e-05])
-        eph3 = ceres.to_ref(pha_test, append_results=True)
-        eph4 = ceres.to_ref(pha_test, normalized=0*u.deg, append_results=True)
-        assert set(eph3.field_names) == {'alpha', 'ref'}
-        assert np.isclose(eph3['ref'], ref2_test).all()
-        assert set(eph4.field_names) == {'alpha', 'ref'}
-        assert np.isclose(eph4['ref'], ref2_norm_test).all()
-        eph5 = ceres.to_ref(eph3, append_results=True)
-        assert set(eph5.field_names) == {'alpha', 'ref', 'ref1'}
-        assert np.isclose(eph5['ref'], eph5['ref1']).all()
-
-        ceres = HG(3.34, 0.12, radius=480)
+        ceres = HG(3.34 * u.mag, 0.12, radius=480)
         eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10)*u.rad,
                     'r': np.repeat(2.7*u.au, 10),
                     'delta': np.repeat(1.8*u.au, 10)}
@@ -340,17 +258,16 @@ class TestHG:
              0.004384267859347806, 0.0026347477224558857,
              0.0014383641304522461, 0.0006498514365555728,
              0.0002042614521939071, 3.1202240400267656e-05,
-             5.942043286373853e-07])
+             5.942043286373853e-07]) / u.sr
         eph1 = ceres.to_ref(eph_test, append_results=True)
         assert set(eph1.field_names) == {'alpha', 'delta', 'ref', 'r'}
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph1['ref'], ref1_test *
-                             u.dimensionless_unscaled).all()
-        pha_test = np.linspace(0, np.pi*0.9, 10)
+            assert u.allclose(eph1['ref'], ref1_test)
+        pha_test = np.linspace(0, np.pi*0.9, 10) * u.rad
         ref2_test = np.array(
             [2.87222512e-02, 1.17208744e-02, 7.05333491e-03, 4.38426786e-03,
              2.63474772e-03, 1.43836413e-03, 6.49851437e-04, 2.04261452e-04,
-             3.12022404e-05, 5.94204329e-07])*u.dimensionless_unscaled
+             3.12022404e-05, 5.94204329e-07]) / u.sr
         ref2_norm_test = np.array(
             [1.00000000e+00, 4.08076452e-01, 2.45570407e-01, 1.52643601e-01,
              9.17319364e-02, 5.00783911e-02, 2.26253657e-02, 7.11161011e-03,
@@ -360,10 +277,11 @@ class TestHG:
         assert set(eph3.field_names) == {'alpha', 'ref'}
         assert set(eph4.field_names) == {'alpha', 'ref'}
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(eph3['ref'], ref2_test *
-                             u.dimensionless_unscaled).all()
-            assert u.isclose(eph4['ref'], ref2_norm_test *
-                             u.dimensionless_unscaled).all()
+            assert u.allclose(eph3['ref'], ref2_test)
+            assert u.allclose(eph4['ref'], ref2_norm_test)
+        ref5 = ceres.to_ref(pha_test)
+        if LooseVersion(astropy.__version__) >= req_ver:
+            assert u.allclose(ref5, ref2_test)
 
     def test_g_validate(self):
         with pytest.warns(NonmonotonicPhaseFunctionWarning):
@@ -413,8 +331,8 @@ class TestHG1G2:
             [7.063, 8.07436233, 8.68048572,
              9.29834638, 9.96574599, 10.72080704, 11.52317465, 12.15094612,
              18.65369516, 18.65389398])
-        assert np.isclose(HG1G2.evaluate(
-            pha_test, 7.063, 0.62, 0.14), phi_test).all()
+        assert np.allclose(HG1G2.evaluate(
+            pha_test, 7.063, 0.62, 0.14), phi_test)
 
     def test_fit_deriv(self):
         pha_test = np.linspace(0, np.pi*0.999, 10)
@@ -430,8 +348,8 @@ class TestHG1G2:
               -2.70127334e+00, -2.84126028e+00, -2.60646207e+00,
               -1.48753067e+00, -1.91400644e-01, -7.75525861e+00,
               -7.75525861e+00]])
-        assert np.isclose(np.array(HG1G2.fit_deriv(
-            pha_test, 7.063, 0.62, 0.14)), deriv_test).all()
+        assert np.allclose(np.array(HG1G2.fit_deriv(
+            pha_test, 7.063, 0.62, 0.14)), deriv_test)
 
     def test_props(self):
         themis = HG1G2(7.063, 0.62, 0.14, radius=100)
@@ -471,14 +389,6 @@ class TestHG1G2:
             m.G2.value, 0.17262569) & (m.G2.unit == u.dimensionless_unscaled)
 
     def test_mag(self):
-        themis = HG1G2(7.063, 0.62, 0.14, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)
-        mag_test = np.array([7.063, 8.07436233, 8.68048572,
-                             9.29834638, 9.96574599, 10.72080704,
-                             11.52317465, 12.15094612,
-                             18.65369516, 18.65389398])
-        assert np.isclose(themis.to_mag(pha_test), mag_test).all()
-
         themis = HG1G2(7.063*u.mag, 0.62*u.dimensionless_unscaled,
                        0.14*u.dimensionless_unscaled, radius=100)
         pha_test = np.linspace(0, np.pi, 10)*u.rad
@@ -487,18 +397,9 @@ class TestHG1G2:
                              11.52317465, 12.15094612,
                              18.65369516, 18.65389398])*u.mag
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.to_mag(pha_test), mag_test).all()
+            assert u.allclose(themis.to_mag(pha_test), mag_test)
 
     def test_ref(self):
-        themis = HG1G2(7.063, 0.62, 0.14, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)
-        ref_test = np.array(
-            [2.14536381e-02, 8.45193252e-03, 4.83622683e-03,
-             2.73755213e-03, 1.48048003e-03, 7.38546998e-04,
-             3.52720817e-04, 1.97843827e-04, 4.95704528e-07,
-             4.95613763e-07])
-        assert np.isclose(themis.to_ref(pha_test), ref_test).all()
-
         themis = HG1G2(7.063*u.mag, 0.62*u.dimensionless_unscaled,
                        0.14*u.dimensionless_unscaled, radius=100)
         pha_test = np.linspace(0, np.pi, 10)*u.rad
@@ -508,7 +409,7 @@ class TestHG1G2:
              3.52720817e-04, 1.97843827e-04, 4.95704528e-07,
              4.95613763e-07])/u.sr
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.to_ref(pha_test), ref_test).all()
+            assert u.allclose(themis.to_ref(pha_test), ref_test)
 
     def test_g1g2_validator(self):
         with pytest.warns(NonmonotonicPhaseFunctionWarning):
@@ -540,8 +441,8 @@ class TestHG12:
             [7.121, 8.07252953, 8.67890827,
              9.2993879, 9.96817595, 10.72086969, 11.51208664, 12.12722017,
              18.70628001, 18.70647883])
-        assert np.isclose(HG12.evaluate(pha_test, 7.121, 0.68),
-                          phi_test).all()
+        assert np.allclose(HG12.evaluate(pha_test, 7.121, 0.68),
+                          phi_test)
 
     def test_fit_deriv(self):
         pha_test = np.linspace(0, np.pi, 10)
@@ -554,8 +455,8 @@ class TestHG12:
               5.38630727e-01, 6.48853898e-01, 4.61007626e-01,
               -4.18315316e-01, -1.40406486e+00, 4.72646358e+00,
               4.72646358e+00]])
-        assert np.isclose(np.array(HG12.fit_deriv(
-            pha_test, 7.121, 0.68)), phi_test).all()
+        assert np.allclose(np.array(HG12.fit_deriv(
+            pha_test, 7.121, 0.68)), phi_test)
 
     def test_props(self):
         themis = HG12(7.121, 0.68, radius=100)
@@ -593,34 +494,24 @@ class TestHG12:
             m.G12.value, 0.44872) & (m.G12.unit == u.dimensionless_unscaled)
 
     def test_mag(self):
-        themis = HG12(7.121, 0.68, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)
+        pha_test = np.linspace(0, np.pi, 10) * u.rad
         mag_test = np.array(
           [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595, 10.72086969,
-          11.51208664, 12.12722017, 18.70628001, 18.70647883])
-        assert np.isclose(themis.to_mag(pha_test), mag_test).all()
-
+          11.51208664, 12.12722017, 18.70628001, 18.70647883]) * u.mag
         themis = HG12(7.121*u.mag, 0.68*u.dimensionless_unscaled, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)*u.rad
-        mag_test = mag_test * u.mag
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.to_mag(pha_test), mag_test).all()
+            assert u.allclose(themis.to_mag(pha_test), mag_test)
 
     def test_ref(self):
-        themis = HG12(7.121, 0.68, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)
+        pha_test = np.linspace(0, np.pi, 10) * u.rad
         ref_test = np.array(
             [2.03376585e-02, 8.46621202e-03, 4.84325842e-03,
              2.73492734e-03, 1.47717032e-03, 7.38504380e-04,
              3.56341412e-04, 2.02214774e-04, 4.72268466e-07,
-             4.72181992e-07])
-        assert np.isclose(themis.to_ref(pha_test), ref_test).all()
-
+             4.72181992e-07]) / u.sr
         themis = HG12(7.121*u.mag, 0.68*u.dimensionless_unscaled, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)*u.rad
-        ref_test = ref_test / u.sr
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.to_ref(pha_test), ref_test).all()
+            assert u.allclose(themis.to_ref(pha_test), ref_test)
 
     def test_g_validator(self):
         with pytest.warns(NonmonotonicPhaseFunctionWarning):
@@ -650,8 +541,8 @@ class TestHG12_Pen16:
         phi_test = np.array(
             [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595,
              10.72086969, 11.51208664, 12.12722017, 18.70628001, 18.70647883])
-        assert np.isclose(HG12_Pen16.evaluate(pha_test, 7.121, 0.68),
-                          phi_test).all()
+        assert np.allclose(HG12_Pen16.evaluate(pha_test, 7.121, 0.68),
+                          phi_test)
 
     def test_fit_deriv(self):
         pha_test = np.linspace(0, np.pi, 10)
@@ -664,8 +555,8 @@ class TestHG12_Pen16:
               4.70632181e-01, 5.65925756e-01, 4.02776061e-01,
               -4.11888156e-01, -1.43862153e+00, 3.39292564e+00,
               3.39292564e+00]])
-        assert np.isclose(np.array(HG12_Pen16.fit_deriv(
-            pha_test, 7.121, 0.68)), phi_test).all()
+        assert np.allclose(np.array(HG12_Pen16.fit_deriv(
+            pha_test, 7.121, 0.68)), phi_test)
 
     def test_props(self):
         themis = HG12_Pen16(7.121, 0.68, radius=100)
@@ -703,35 +594,25 @@ class TestHG12_Pen16:
             m.G12.value, 0.631243) & (m.G12.unit == u.dimensionless_unscaled)
 
     def test_mag(self):
-        themis = HG12_Pen16(7.121, 0.68, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)
+        pha_test = np.linspace(0, np.pi, 10) * u.rad
         mag_test = np.array(
           [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595, 10.72086969,
-           11.51208664, 12.12722017, 18.70628001, 18.70647883])
-        assert np.isclose(themis.to_mag(pha_test), mag_test).all()
-
+           11.51208664, 12.12722017, 18.70628001, 18.70647883]) * u.mag
         themis = HG12_Pen16(7.121*u.mag, 0.68 *
                             u.dimensionless_unscaled, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)*u.rad
-        mag_test = mag_test*u.mag
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.to_mag(pha_test), mag_test).all()
+            assert u.allclose(themis.to_mag(pha_test), mag_test)
 
     def test_ref(self):
-        themis = HG12_Pen16(7.121, 0.68, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)
+        pha_test = np.linspace(0, np.pi, 10) * u.rad
         ref_test = np.array(
             [2.03376585e-02, 8.46621202e-03, 4.84325842e-03, 2.73492734e-03,
              1.47717032e-03, 7.38504380e-04, 3.56341412e-04, 2.02214774e-04,
-             4.72268466e-07, 4.72181992e-07])
-        assert np.isclose(themis.to_ref(pha_test), ref_test).all()
-
+             4.72268466e-07, 4.72181992e-07]) / u.sr
         themis = HG12_Pen16(7.121*u.mag, 0.68 *
                             u.dimensionless_unscaled, radius=100)
-        pha_test = np.linspace(0, np.pi, 10)*u.rad
-        ref_test = ref_test / u.sr
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.to_ref(pha_test), ref_test).all()
+            assert u.allclose(themis.to_ref(pha_test), ref_test)
 
     def test_g_validator(self):
         with pytest.warns(NonmonotonicPhaseFunctionWarning):


### PR DESCRIPTION
This PR adds an option for `quantity_to_dataclass` decorator to check the unit of input quantity, similar to what `astropy.units.quantity_input` does:

```
import astropy.units as u
import sbpy.data as sbd
@sbd.quantity_to_dataclass(eph=(sbd.Ephem, 'rh', 'length'))
def temperature(eph):
    return 278 * u.K / (eph['rh'] / u.au)**0.5
print(temperature(1 * u.s))
```

Raise exception:

```
UnitsError: Argument 'eph' to function 'temperature' must be in units convertible to 'm'.
```

This is needed in order to enforce quantity input for our functions.  I tried to stack the `astropy.units.quantity_input` decorator with our `quantity_to_dataclass` decorator but it doesn't work when the input is already a `DataClass` object.

This implementation uses some internal functions of `astropy.units.decorators`.  If no objections, I'll merge it in a day.