### PR TITLE
Deprecate `mag2ref` and `ref2mag`

### DIFF
--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -38,7 +38,8 @@ by supplying the model parameters as either dimensionless numbers or
        H   G
       --- ---
       8.0 0.4
-  >>> m = HG(H=3.34*u.mag, G=0.12*u.dimensionless_unscaled, radius=460*u.km)
+
+  >>> m = HG(H = 3.34 * u.mag, G = 0.12, radius = 460 * u.km, wfb = 'V')
   >>> print(m)
   Model: HG
   Inputs: ('x',)
@@ -50,18 +51,30 @@ by supplying the model parameters as either dimensionless numbers or
       ---- ----
       3.34 0.12
 
+The calculations that involve conversion between magnitude and reflectance
+requires valid object size and `wfb` (wavelength/frequency/band) parameter to
+be set for the photometric model.  The corresponding solar flux at the `wfb`
+of the photometric model object has to be available through `~sbpy.calib`
+system, or set by `~sbpy.calib.solar_fluxd.set`, which works with context
+management `with` syntax.
+
 Calculate geometric albedo, Bond albedo, and phase integral:
 
+  >>> import astropy.units as u
+  >>> from sbpy.calib import solar_fluxd
+  >>> solar_fluxd.set({'V': -26.77 * u.mag})
   >>> print(m.geomalb)  # doctest: +FLOAT_CMP
-  0.09825058857735823
+  0.09557298727307795
   >>> print(m.bondalb)  # doctest: +FLOAT_CMP
-  0.035797658494252343
+  0.03482207291799989
   >>> print(m.phaseint)  # doctest: +FLOAT_CMP
-  0.36435057552929395
+  0.3643505755292945
 
-Users can supply a solar magnitude corresponding to the magnitude system of
-the H-parameter.  The default is the apparent V-magnitude of the Sun,
-M_sun = -26.74 mag.
+Note that the current version of `astropy.modeling.Model` doesn't support
+`astropy.units.MagUnit` instance as model parameters.  For now one has to use
+the dimensionless magnitude `~astropy.units.mag` in the phase function
+parameter, and manually set solar flux in order for the conversion between
+magnitude and reflectance to work.
 
 The model class can also be initialized by a subclass of ``sbpy``'s
 `~sbpy.data.DataClass`, such as `~sbpy.data.Phys`, as long as it contains the
@@ -90,11 +103,12 @@ the fitter classes defined in `astropy.modeling.fitting`
 submodule, such as `~astropy.modeling.fitting.LevMarLSQFitter`.
 
   >>> import numpy as np
+  >>> import astropy.units as u
   >>> from astropy.modeling.fitting import LevMarLSQFitter
   >>> # generate data to be fitted
-  >>> model1 = HG(3.34, 0.12)
+  >>> model1 = HG(3.34 * u .mag, 0.12)
   >>> alpha = np.linspace(0, 40, 20) * u.deg
-  >>> mag = model1(alpha) + np.random.rand(20)*0.2-0.1
+  >>> mag = model1(alpha) + (np.random.rand(20)*0.2 - 0.1) * u.mag
   >>> # fit new model
   >>> fitter = LevMarLSQFitter()
   >>> model2 = HG()
@@ -118,8 +132,8 @@ measurements.  The columns to be fitted are specified by a keyward argument
 ``fields``.  By default, the column ``'mag'`` will be fitted.
 
   >>> # Initialize model set
-  >>> model4 = HG(5.2, 0.18)
-  >>> mag4 = model4(alpha) + np.random.rand(20)*0.2-0.1
+  >>> model4 = HG(5.2 * u.mag, 0.18)
+  >>> mag4 = model4(alpha) + (np.random.rand(20)*0.2 - 0.1) * u.mag
   >>> fitter = LevMarLSQFitter()
   >>> obs = Obs.from_dict({'alpha': alpha, 'mag': mag, 'mag1': mag4})
   >>> model5 = HG.from_obs(obs, fitter, fields=['mag', 'mag1'])

--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -63,6 +63,7 @@ Calculate geometric albedo, Bond albedo, and phase integral:
   >>> import astropy.units as u
   >>> from sbpy.calib import solar_fluxd
   >>> solar_fluxd.set({'V': -26.77 * u.mag})
+  <ScienceState solar_fluxd: {'V': <Quantity -26.77 mag>}>
   >>> print(m.geomalb)  # doctest: +FLOAT_CMP
   0.09557298727307795
   >>> print(m.bondalb)  # doctest: +FLOAT_CMP

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -691,17 +691,19 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
             if normalized is not None:
                 out /= norm
         else:
-            if self.radius is None:
-                raise ValueError(
-                    'Cannot calculate phase function in reflectance unit'
-                    ' because the size of object is unknown.')
-            if self.wfb is None:
-                raise ValueError('Wavelength/Frequency/Band is unknown.')
-            out = out.to('1/sr', reflectance(self.wfb,
-                    cross_section=np.pi*self.radius**2))
-            if normalized is not None:
-                out /= norm.to('1/sr', reflectance(self.wfb,
+            if normalized is None:
+                if self.radius is None:
+                    raise ValueError(
+                        'Cannot calculate phase function in reflectance unit'
+                        ' because the size of object is unknown.  Normalized'
+                        ' phase function can be calculated.')
+                if self.wfb is None:
+                    raise ValueError('Wavelength/Frequency/Band is unknown.')
+                out = out.to('1/sr', reflectance(self.wfb,
                         cross_section=np.pi*self.radius**2))
+            else:
+                out = out - norm
+                out = out.to('', u.logarithmic())
         if append_results:
             name = 'ref'
             i = 1
@@ -739,7 +741,8 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
         0.364
         """
         def integrand(x):
-            return 2*self.to_ref(x*u.rad, normalized=0.*u.rad)*np.sin(x)
+            return 2*self.to_ref(x * u.rad, normalized=0. * u.rad) * \
+                np.sin(x * u.rad)
         return integrator(integrand, 0, np.pi)[0]
 
 

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -349,11 +349,13 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
 
         Examples
         --------
+        >>> import astropy.units as u
+        >>> from sbpy.calib import solar_fluxd
         >>> from sbpy.photometry import HG
         >>> from sbpy.data import Phys
         >>>
         >>> # Initialize from physical parameters pulled from JPL SBDB
-        >>> phys = Phys.from_sbdb('Ceres')    # doctest: +REMOTE_DATA
+        >>> phys = Phys.from_sbdb('Ceres')             # doctest: +REMOTE_DATA
         >>> print(phys['targetname','radius','H','G']) # doctest: +REMOTE_DATA
         <QTable length=1>
         targetname  radius    H       G
@@ -361,18 +363,21 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
            str7    float64 float64 float64
         ---------- ------- ------- -------
            1 Ceres   469.7    3.34    0.12
-        >>> m = HG.from_phys(phys)  # doctest: +REMOTE_DATA
+        >>> m = HG.from_phys(phys)   # doctest: +REMOTE_DATA
         INFO: Model initialized for 1 Ceres. [sbpy.photometry.core]
-        >>> p = m.to_phys()  # doctest: +REMOTE_DATA
-        >>> print(type(p))  # doctest: +REMOTE_DATA
+        >>> m.wfb = 'V'              # doctest: +REMOTE_DATA
+        >>> m.H = m.H * u.mag        # doctest: +REMOTE_DATA
+        >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+        ...     p = m.to_phys()      # doctest: +REMOTE_DATA
+        >>> print(type(p))           # doctest: +REMOTE_DATA
         <class 'sbpy.data.phys.Phys'>
-        >>> print(p)  # doctest: +REMOTE_DATA
+        >>> print(p)                 # doctest: +REMOTE_DATA
         <QTable length=1>
         targetname diameter    H       G             pv                  A
-                      km
+                      km      mag
            str7    float64  float64 float64       float64             float64
         ---------- -------- ------- ------- ------------------- -------------------
-           1 Ceres    939.4    3.34    0.12 0.09423445077857852 0.03433437637586201
+           1 Ceres    939.4    3.34    0.12 0.09166630037900923 0.03339866929973315
         """
         cols = {}
         if (self.meta is not None) and ('targetname' in self.meta.keys()):

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -1205,4 +1205,3 @@ class HG12_Pen16(HG12):
         p2 = -0.53513350
         ddg = 1.085736205*((phi3-phi1)*p1+(phi3-phi2)*p2)/dom
         return [ddh, ddg]
-

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -108,7 +108,9 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
 
     >>> # Define a disk-integrated phase function model
     >>> import numpy as np
+    >>> import astropy.units as u
     >>> from astropy.modeling import Parameter
+    >>> from sbpy.calib import solar_fluxd
     >>> from sbpy.photometry import DiskIntegratedPhaseFunc
     >>>
     >>> class LinearPhaseFunc(DiskIntegratedPhaseFunc):
@@ -122,17 +124,18 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
     ...         return H + S * a
     ...
     >>> linear_phasefunc = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
-    ...     radius=300)
+    ...     radius = 300 * u.km, wfb = 'V')
     >>> pha = np.linspace(0, 180, 200) * u.deg
-    >>> mag = linear_phasefunc.to_mag(pha)
-    >>> ref = linear_phasefunc.to_ref(pha)
-    >>> geomalb = linear_phasefunc.geomalb
-    >>> phaseint = linear_phasefunc.phaseint
-    >>> bondalb = linear_phasefunc.bondalb
+    >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+    ...     mag = linear_phasefunc.to_mag(pha)
+    ...     ref = linear_phasefunc.to_ref(pha)
+    ...     geomalb = linear_phasefunc.geomalb
+    ...     phaseint = linear_phasefunc.phaseint
+    ...     bondalb = linear_phasefunc.bondalb
     >>> print('Geometric albedo is {0:.3}'.format(geomalb))
-    Geometric albedo is 0.0501
+    Geometric albedo is 0.0487
     >>> print('Bond albedo is {0:.3}'.format(bondalb))
-    Bond albedo is 0.0184
+    Bond albedo is 0.0179
     >>> print('Phase integral is {0:.3}'.format(phaseint))
     Phase integral is 0.367
 
@@ -587,7 +590,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
         ...              'delta': np.repeat(1.8*u.au, 200)})
         >>> mag1 = ceres_hg.to_mag(eph)
         >>> # parameter `eph` as numpy array
-        >>> pha = np.linspace(0, 180, 200) * u.deg
+        >>> pha = np.linspace(0, 170, 200) * u.deg
         >>> mag2 = ceres_hg.to_mag(pha)
         """
         self._check_unit()
@@ -663,17 +666,19 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
         --------
         >>> import numpy as np
         >>> from astropy import units as u
+        >>> from sbpy.calib import solar_fluxd
         >>> from sbpy.photometry import HG
         >>> from sbpy.data import Ephem
-        >>> ceres_hg = HG(3.34, 0.12, radius=480)
+        >>> ceres_hg = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb= 'V')
         >>> # parameter `eph` as `~sbpy.data.Ephem` type
         >>> eph = Ephem.from_dict({'alpha': np.linspace(0,np.pi*0.9,200)*u.rad,
         ...              'r': np.repeat(2.7*u.au, 200),
         ...              'delta': np.repeat(1.8*u.au, 200)})
-        >>> ref1 = ceres_hg.to_ref(eph)
-        >>> # parameter `eph` as numpy array
-        >>> pha = np.linspace(0, 180, 200) * u.deg
-        >>> ref2 = ceres_hg.to_ref(pha)
+        >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+        ...     ref1 = ceres_hg.to_ref(eph)
+        ...     # parameter `eph` as numpy array
+        ...     pha = np.linspace(0, 170, 200) * u.deg
+        ...     ref2 = ceres_hg.to_ref(pha)
         """
         self._check_unit()
         pha = eph['alpha']
@@ -725,11 +730,13 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
 
         Examples
         --------
+        >>> import astropy.units as u
+        >>> from sbpy.calib import solar_fluxd
         >>> from sbpy.photometry import HG
-        >>> ceres_hg = HG(3.34, 0.12, radius=480)
-        >>> print('{0:.3}'.format(ceres_hg._phase_integral()))
+        >>> ceres_hg = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+        ...     print('{0:.3}'.format(ceres_hg._phase_integral()))
         0.364
-
         """
         def integrand(x):
             return 2*self.to_ref(x*u.rad, normalized=0.*u.rad)*np.sin(x)
@@ -743,20 +750,23 @@ class LinearPhaseFunc(DiskIntegratedPhaseFunc):
     --------
     >>> # Define a linear phase function model with absolute magnitude
     >>> # H = 5 and slope = 0.04 mag/deg = 2.29 mag/rad
+    >>> import astropy.units as u
+    >>> from sbpy.calib import solar_fluxd
     >>> from sbpy.photometry import LinearPhaseFunc
     >>>
     >>> linear_phasefunc = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
-    ...     radius=300)
-    >>> pha = np.linspace(0, 180, 200) * u.deg
-    >>> mag = linear_phasefunc.to_mag(pha)
-    >>> ref = linear_phasefunc.to_ref(pha)
-    >>> geomalb = linear_phasefunc.geomalb
-    >>> phaseint = linear_phasefunc.phaseint
-    >>> bondalb = linear_phasefunc.bondalb
+    ...     radius = 300 * u.km, wfb = 'V')
+    >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+    ...     pha = np.linspace(0, 180, 200) * u.deg
+    ...     mag = linear_phasefunc.to_mag(pha)
+    ...     ref = linear_phasefunc.to_ref(pha)
+    ...     geomalb = linear_phasefunc.geomalb
+    ...     phaseint = linear_phasefunc.phaseint
+    ...     bondalb = linear_phasefunc.bondalb
     >>> print('Geometric albedo is {0:.3}'.format(geomalb))
-    Geometric albedo is 0.0501
+    Geometric albedo is 0.0487
     >>> print('Bond albedo is {0:.3}'.format(bondalb))
-    Bond albedo is 0.0184
+    Bond albedo is 0.0179
     >>> print('Phase integral is {0:.3}'.format(phaseint))
     Phase integral is 0.367
 
@@ -792,12 +802,15 @@ class HG(DiskIntegratedPhaseFunc):
     --------
 
     >>> # Define the phase function for Ceres with H = 3.34, G = 0.12
+    >>> import astropy.units as u
+    >>> from sbpy.calib import solar_fluxd
     >>> from sbpy.photometry import HG
-    >>> ceres = HG(3.34, 0.12, radius=480)
-    >>> print('{0:.4f}'.format(ceres.geomalb))
-    0.0902
-    >>> print('{0:.4f}'.format(ceres.phaseint))
-    0.3644
+    >>> ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+    >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+    ...     print('geometric albedo = {0:.4f}'.format(ceres.geomalb))
+    ...     print('phase integral = {0:.4f}'.format(ceres.phaseint))
+    geometric albedo = 0.0878
+    phase integral = 0.3644
 
     """
 
@@ -959,13 +972,16 @@ class HG1G2(HG12BaseClass):
     >>> # Define the phase function for Themis with
     >>> # H = 7.063, G1 = 0.62, G2 = 0.14
     >>>
+    >>> import astropy.units as u
+    >>> from sbpy.calib import solar_fluxd
     >>> from sbpy.photometry import HG1G2
-    >>> themis = HG1G2(7.063,0.62,0.14,radius=100)
-    >>> print('{0:.4f}'.format(themis.geomalb))
-    0.0674
-    >>> print('{0:.4f}'.format(themis.phaseint))
-    0.3742
-
+    >>> themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
+    ...     wfb = 'V')
+    >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+    ...     print('geometric albedo = {0:.4f}'.format(themis.geomalb))
+    ...     print('phase integral = {0:.4f}'.format(themis.phaseint))
+    geometric albedo = 0.0656
+    phase integral = 0.3742
     """
 
     H = Parameter(description='H parameter', default=8)
@@ -1050,12 +1066,15 @@ class HG12(HG12BaseClass):
     >>> # Define the phase function for Themis with
     >>> # H = 7.121, G12 = 0.68
     >>>
+    >>> import astropy.units as u
+    >>> from sbpy.calib import solar_fluxd
     >>> from sbpy.photometry import HG12
-    >>> themis = HG12(7.121, 0.68, radius=100)
-    >>> print('{0:.4f}'.format(themis.geomalb))
-    0.0639
-    >>> print('{0:.4f}'.format(themis.phaseint))
-    0.3949
+    >>> themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
+    >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+    ...     print('geometric albedo = {0:.4f}'.format(themis.geomalb))
+    ...     print('phase integral = {0:.4f}'.format(themis.phaseint))
+    geometric albedo = 0.0622
+    phase integral = 0.3949
 
     """
 
@@ -1144,13 +1163,16 @@ class HG12_Pen16(HG12):
     >>> # Define the phase function for Themis with
     >>> # H = 7.121, G12 = 0.68
     >>>
-    >>> from sbpy.photometry import HG12
-    >>> themis = HG12_Pen16(7.121, 0.68, radius=100)
-    >>> print('{0:.4f}'.format(themis.geomalb))
-    0.0639
-    >>> print('{0:.4f}'.format(themis.phaseint))
-    0.3804
-
+    >>> import astropy.units as u
+    >>> from sbpy.calib import solar_fluxd
+    >>> from sbpy.photometry import HG12_Pen16
+    >>> themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
+    ...     wfb = 'V')
+    >>> with solar_fluxd.set({'V': -26.77 * u.mag}):
+    ...     print('geometric albedo = {0:.4f}'.format(themis.geomalb))
+    ...     print('phase integral = {0:.4f}'.format(themis.phaseint))
+    geometric albedo = 0.0622
+    phase integral = 0.3804
     """
 
     @cite({'definition': '2016P&SS..123..117P'})
@@ -1183,3 +1205,4 @@ class HG12_Pen16(HG12):
         p2 = -0.53513350
         ddg = 1.085736205*((phi3-phi1)*p1+(phi3-phi2)*p2)/dom
         return [ddh, ddg]
+

--- a/sbpy/photometry/tests/test_core.py
+++ b/sbpy/photometry/tests/test_core.py
@@ -37,7 +37,7 @@ class TestDiskIntegratedPhaseFunc():
 
         exp_phase = ExpPhase()
         pha_test = np.linspace(0, 120, 10) * u.deg
-        ref_test = [0.1, 0.09769976, 0.09545244, 0.0932568 , 0.09111168,
+        ref_test = [0.1, 0.09769976, 0.09545244, 0.0932568, 0.09111168,
                     0.08901589, 0.08696831, 0.08496784, 0.08301337,
                     0.08110387] / u.sr
         ref = exp_phase(pha_test)

--- a/sbpy/photometry/tests/test_core.py
+++ b/sbpy/photometry/tests/test_core.py
@@ -473,6 +473,9 @@ class TestHG12:
         themis = HG12(7.121 * u.mag, 0.68)
         assert np.isclose(themis._G1, 0.669592)
         assert np.isclose(themis._G2, 0.1407)
+        themis = HG12(7.121 * u.mag, 0.1)
+        assert np.isclose(themis._G1, 0.13691)
+        assert np.isclose(themis._G2, 0.53088)
 
     def test_evaluate(self):
         pha_test = np.linspace(0, np.pi, 10)
@@ -502,6 +505,8 @@ class TestHG12:
         assert np.isclose(themis.geomalb, 0.06215139)
         assert np.isclose(themis.bondalb, 0.02454096)
         assert np.isclose(themis.phaseint, 0.3948577512)
+        assert np.isclose(themis.phasecoeff, -1.6777182566684201)
+        assert np.isclose(themis.oe_amp, 0.23412300750840437)
 
     def test_from_obs(self):
         pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,

--- a/sbpy/photometry/tests/test_core.py
+++ b/sbpy/photometry/tests/test_core.py
@@ -6,38 +6,30 @@ from distutils.version import LooseVersion
 import astropy
 from astropy import units as u
 from astropy.modeling import Parameter
+from ...calib import solar_fluxd
 from ..core import *
 from ...data import Ephem, Phys
 
 req_ver = LooseVersion('3.0.2')
 
-
-def test_ref2mag():
-    assert np.isclose(ref2mag(0.1/np.pi, 460), 3.3208379018205285)
-    if LooseVersion(astropy.__version__) >= req_ver:
-        assert u.isclose(ref2mag(0.1/np.pi, 460*u.km),
-                         3.3208379018205285*u.mag)
-
-
-def test_mag2ref():
-    assert np.isclose(mag2ref(3.32, 460), 0.03185556322261901)
-    if LooseVersion(astropy.__version__) >= req_ver:
-        assert u.isclose(mag2ref(3.32, 460*u.km), 0.03185556322261901/u.sr)
-
+solar_fluxd.set({'V': -26.77 * u.mag})
 
 class TestLinear():
     def test_init(self):
-        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg, radius=300)
+        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
+                radius = 300 * u.km, wfb = 'V')
         assert np.isclose(linphase.H.value, 5)
         assert linphase.H.unit == u.mag
         assert np.isclose(linphase.S.value, 0.04)
         assert linphase.S.unit == u.mag/u.deg
+        assert linphase.radius == 300 * u.km
+        assert linphase.wfb == 'V'
 
-    def test_mag(self):
-        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg, radius=300)
+    def test_to_mag(self):
+        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
+                radius = 300 * u.km)
         pha_test = np.linspace(0, np.pi, 10) * u.rad
-        mag_test = np.array([5., 5.8, 6.6, 7.4, 8.2, 9., 9.8, 10.6, 11.4,
-            12.2]) * u.mag
+        mag_test = [5., 5.8, 6.6, 7.4, 8.2, 9., 9.8, 10.6, 11.4, 12.2] * u.mag
         eph = linphase.to_mag(pha_test, append_results=True)
         assert np.allclose(eph['mag'].value, mag_test.value)
         assert eph['mag'].unit == mag_test.unit
@@ -45,14 +37,14 @@ class TestLinear():
         assert eph['alpha'].unit == pha_test.unit
         assert set(eph.field_names) == {'alpha', 'mag'}
 
-    def test_ref(self):
-        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg, radius=300)
+    def test_to_ref(self):
+        linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
+                radius = 300 * u.km, wfb = 'V')
         pha_test = np.linspace(0, 180, 10) * u.deg
         eph = linphase.to_ref(pha_test, append_results=True)
-        ref_test = np.array(
-            [1.59389035e-02, 7.62883887e-03, 3.65139185e-03, 1.74766602e-03,
-             8.36485548e-04, 4.00367155e-04, 1.91627768e-04, 9.17188165e-05,
-             4.38993856e-05, 2.10115670e-05])/u.sr
+        ref_test = [1.55045242e-02, 7.42093183e-03, 3.55188129e-03,
+            1.70003727e-03, 8.13688994e-04, 3.89456039e-04, 1.86405380e-04,
+            8.92192241e-05, 4.27030055e-05, 2.04389434e-05] / u.sr
         ref_norm_test = np.array(
             [1., 0.47863009, 0.22908677, 0.10964782, 0.05248075,
              0.02511886, 0.01202264, 0.0057544, 0.00275423,
@@ -61,17 +53,19 @@ class TestLinear():
             assert u.allclose(eph['ref'], ref_test)
             assert u.allclose(eph['alpha'], pha_test)
         assert set(eph.field_names) == {'alpha', 'ref'}
-        eph_norm = linphase.to_ref(pha_test, normalized=0*u.deg, append_results=True)
+        eph_norm = linphase.to_ref(pha_test, normalized = 0 * u.deg,
+            append_results=True)
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(eph_norm['ref'], ref_norm_test)
             assert u.allclose(eph_norm['alpha'], pha_test)
         assert set(eph_norm.field_names) == {'alpha', 'ref'}
 
     def test_props(self):
-        linphase = LinearPhaseFunc(5 * u.mag, 2.29 * u.mag/u.rad, radius=300)
-        assert np.isclose(linphase.geomalb, 0.05007354222252798)
-        assert np.isclose(linphase.bondalb, 0.018404727835791654)
-        assert np.isclose(linphase.phaseint, 0.3675539420399024)
+        linphase = LinearPhaseFunc(5 * u.mag, 2.29 * u.mag/u.rad,
+                radius = 300 * u.km, wfb = 'V')
+        assert np.isclose(linphase.geomalb, 0.0487089)
+        assert np.isclose(linphase.bondalb, 0.01790315)
+        assert np.isclose(linphase.phaseint, 0.36755394203990327)
 
     def test__distance_module(self):
         r = [0.5, 1, 1.2, 2]
@@ -89,20 +83,14 @@ class TestLinear():
 class TestHG:
     def test_init(self):
         # initialize with numbers
-        ceres = HG(3.34, 0.12, radius=480*u.km, M_sun=-26.74)
+        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(ceres.radius, 480*u.km)
-        assert np.isclose(ceres.M_sun, -26.74)
+            assert u.isclose(ceres.radius, 480 * u.km)
         assert isinstance(ceres.H, Parameter)
         assert np.isclose(ceres.H.value, 3.34)
         assert isinstance(ceres.G, Parameter)
         assert np.isclose(ceres.G.value, 0.12)
-        # initialize with Quantity
-        ceres = HG(3.34 * u.mag, 0.12 * u.dimensionless_unscaled)
-        assert np.isclose(ceres.H.value, 3.34)
-        assert ceres.H.unit == u.mag
-        assert np.isclose(ceres.G.value, 0.12)
-        assert ceres.G.unit == u.dimensionless_unscaled
+        assert ceres.wfb == 'V'
 
     @pytest.mark.remote_data
     def test_from_phys(self):
@@ -120,17 +108,18 @@ class TestHG:
             m = HG.from_phys(phys)
 
     def test_to_phys(self):
-        m = HG(3.34, 0.12, radius=480*u.km, M_sun=-26.74,
+        m = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V',
                 meta={'targetname': '1 Ceres'})
         p = m.to_phys()
         assert isinstance(p, Phys)
         assert p['targetname'] == '1 Ceres'
-        assert np.isclose(p['H'], 3.34)
+        assert np.isclose(p['H'].value, 3.34)
+        assert p['H'].unit == u.mag
         assert np.isclose(p['G'], 0.12)
         assert np.isclose(p['diameter'].value, 960)
         assert p['diameter'].unit == u.km
-        assert np.isclose(p['pv'], 0.09023361346774741)
-        assert np.isclose(p['A'], 0.03287666899906162)
+        assert np.isclose(p['pv'], 0.0877745)
+        assert np.isclose(p['A'], 0.03198069)
 
     def test_evaluate(self):
         pha_test = np.linspace(0, np.pi, 10)
@@ -151,21 +140,14 @@ class TestHG:
             deriv_test)
 
     def test__check_unit(self):
-        ceres = HG(3.34, 0.12, radius=480*u.km, M_sun=-26.74)
+        ceres = HG(3.34 * u.mag, 0.12)
         assert ceres._unit == 'mag'
 
     def test_props(self):
-        ceres = HG(3.34, 0.12, radius=480)
-        assert np.isclose(ceres.geomalb, 0.09023361346774741)
-        assert np.isclose(ceres.bondalb, 0.03287666899906162)
-        assert np.isclose(ceres.phaseint, 0.36435057552929395)
-        ceres.radius = 480*u.km
-        if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(ceres.geomalb,
-                             0.09023361*u.dimensionless_unscaled)
-            assert u.isclose(ceres.bondalb, 0.03287667 *
-                             u.dimensionless_unscaled)
-        assert np.isclose(ceres.phaseint, 0.36435057552929323)
+        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        assert np.isclose(ceres.geomalb, 0.0877745)
+        assert np.isclose(ceres.bondalb, 0.03198069)
+        assert np.isclose(ceres.phaseint, 0.3643505755292945)
 
     def test_from_obs(self):
         pha = np.array(
@@ -219,8 +201,8 @@ class TestHG:
         assert m.meta['fields'] == ['mag', 'mag1', 'mag2']
 
     def test_to_mag(self):
-        ceres = HG(3.34 * u.mag, 0.12 * u.dimensionless_unscaled, radius=480)
-        eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10)*u.rad,
+        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10) * u.rad,
                     'r': np.repeat(2.7*u.au, 10),
                     'delta': np.repeat(1.8*u.au, 10)}
         eph_test = Ephem.from_dict(eph_dict)
@@ -247,27 +229,20 @@ class TestHG:
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(mag4, mag2_test)
 
-    def test_ref(self):
-        ceres = HG(3.34 * u.mag, 0.12, radius=480)
+    def test_to_ref(self):
+        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
         eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10)*u.rad,
                     'r': np.repeat(2.7*u.au, 10),
                     'delta': np.repeat(1.8*u.au, 10)}
         eph_test = Ephem.from_dict(eph_dict)
-        ref1_test = np.array(
-            [0.02872225123287084, 0.0117208743870569, 0.007053334911678305,
-             0.004384267859347806, 0.0026347477224558857,
-             0.0014383641304522461, 0.0006498514365555728,
-             0.0002042614521939071, 3.1202240400267656e-05,
-             5.942043286373853e-07]) / u.sr
+        ref1_test = [2.79394901e-02, 1.14014480e-02, 6.86111195e-03,
+            4.26478439e-03, 2.56294353e-03, 1.39916471e-03, 6.32141181e-04,
+            1.98694761e-04, 3.03518927e-05, 5.78010611e-07] / u.sr
         eph1 = ceres.to_ref(eph_test, append_results=True)
         assert set(eph1.field_names) == {'alpha', 'delta', 'ref', 'r'}
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(eph1['ref'], ref1_test)
         pha_test = np.linspace(0, np.pi*0.9, 10) * u.rad
-        ref2_test = np.array(
-            [2.87222512e-02, 1.17208744e-02, 7.05333491e-03, 4.38426786e-03,
-             2.63474772e-03, 1.43836413e-03, 6.49851437e-04, 2.04261452e-04,
-             3.12022404e-05, 5.94204329e-07]) / u.sr
         ref2_norm_test = np.array(
             [1.00000000e+00, 4.08076452e-01, 2.45570407e-01, 1.52643601e-01,
              9.17319364e-02, 5.00783911e-02, 2.26253657e-02, 7.11161011e-03,
@@ -277,11 +252,11 @@ class TestHG:
         assert set(eph3.field_names) == {'alpha', 'ref'}
         assert set(eph4.field_names) == {'alpha', 'ref'}
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.allclose(eph3['ref'], ref2_test)
+            assert u.allclose(eph3['ref'], ref1_test)
             assert u.allclose(eph4['ref'], ref2_norm_test)
         ref5 = ceres.to_ref(pha_test)
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.allclose(ref5, ref2_test)
+            assert u.allclose(ref5, ref1_test)
 
     def test_g_validate(self):
         with pytest.warns(NonmonotonicPhaseFunctionWarning):
@@ -291,26 +266,18 @@ class TestHG:
 class TestHG1G2:
     def test_init(self):
         # initialization with numbers
-        themis = HG1G2(7.063, 0.62, 0.14, radius=100.*u.km, M_sun=-26.74)
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
+                wfb = 'V')
         assert themis._unit == 'mag'
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.radius, 100*u.km)
-        assert np.isclose(themis.M_sun, -26.74)
+            assert u.isclose(themis.radius, 100 * u.km)
         assert isinstance(themis.H, Parameter)
         assert np.isclose(themis.H.value, 7.063)
         assert isinstance(themis.G1, Parameter)
         assert np.isclose(themis.G1.value, 0.62)
         assert isinstance(themis.G2, Parameter)
         assert np.isclose(themis.G2.value, 0.14)
-        # initialization with Quantity
-        themis = HG1G2(7.062 * u.mag, 0.62 * u.dimensionless_unscaled,
-                       0.14 * u.dimensionless_unscaled)
-        assert np.isclose(themis.H.value, 7.062)
-        assert themis.H.unit == u.mag
-        assert np.isclose(themis.G1.value, 0.62)
-        assert themis.G1.unit == u.dimensionless_unscaled
-        assert np.isclose(themis.G2.value, 0.14)
-        assert themis.G2.unit == u.dimensionless_unscaled
+        assert themis.wfb == 'V'
 
     @pytest.mark.remote_data
     def test_from_phys(self):
@@ -321,7 +288,7 @@ class TestHG1G2:
             m = HG1G2.from_phys(phys)
 
     def test__G1_G2(self):
-        themis = HG1G2(7.063, 0.62, 0.14, radius=100*u.km, M_sun=-26.74)
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14)
         assert np.isclose(themis._G1, 0.62)
         assert np.isclose(themis._G2, 0.14)
 
@@ -352,31 +319,23 @@ class TestHG1G2:
             pha_test, 7.063, 0.62, 0.14)), deriv_test)
 
     def test_props(self):
-        themis = HG1G2(7.063, 0.62, 0.14, radius=100)
-        assert np.isclose(themis.geomalb, 0.06739859193616704)
-        assert np.isclose(themis.bondalb, 0.02521731797010077)
-        assert np.isclose(themis.phaseint, 0.374152)
-        themis.radius = 100*u.km
-        if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.geomalb, 0.06739859 *
-                             u.dimensionless_unscaled)
-            assert u.isclose(themis.bondalb, 0.02521732 *
-                             u.dimensionless_unscaled)
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
+                wfb = 'V')
+        assert np.isclose(themis.geomalb, 0.06556179)
+        assert np.isclose(themis.bondalb, 0.02453008)
         assert np.isclose(themis.phaseint, 0.374152)
 
     def test_from_obs(self):
-        pha = np.array(
-            [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
-             31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
-             63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
-             94.73684211, 101.05263158, 107.36842105, 113.68421053,
-             120.]) * u.deg
-        data = np.array(
-            [7.14679706, 7.32220201, 7.85637226, 7.98824651, 8.2029765,
-             8.27574759, 8.49437766, 9.05650671, 8.79649221, 9.33071561,
-             9.24703668, 9.49069761, 9.57246629, 10.12429626, 10.14465944,
-             10.51021594, 10.63215313, 11.15570421, 11.44890748,
-             11.43888611]) * u.mag
+        pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
+               31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
+               63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
+               94.73684211, 101.05263158, 107.36842105, 113.68421053,
+               120.] * u.deg
+        data = [7.14679706, 7.32220201, 7.85637226, 7.98824651, 8.2029765,
+                8.27574759, 8.49437766, 9.05650671, 8.79649221, 9.33071561,
+                9.24703668, 9.49069761, 9.57246629, 10.12429626, 10.14465944,
+                10.51021594, 10.63215313, 11.15570421, 11.44890748,
+                11.43888611] * u.mag
         from astropy.modeling.fitting import LevMarLSQFitter
         fitter = LevMarLSQFitter()
         m = HG1G2.from_obs({'alpha': pha, 'mag': data}, fitter)
@@ -388,26 +347,23 @@ class TestHG1G2:
         assert isinstance(m.G2, Parameter) & np.isclose(
             m.G2.value, 0.17262569) & (m.G2.unit == u.dimensionless_unscaled)
 
-    def test_mag(self):
-        themis = HG1G2(7.063*u.mag, 0.62*u.dimensionless_unscaled,
-                       0.14*u.dimensionless_unscaled, radius=100)
+    def test_to_mag(self):
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
+                wfb = 'V')
         pha_test = np.linspace(0, np.pi, 10)*u.rad
-        mag_test = np.array([7.063, 8.07436233, 8.68048572,
-                             9.29834638, 9.96574599, 10.72080704,
-                             11.52317465, 12.15094612,
-                             18.65369516, 18.65389398])*u.mag
+        mag_test = [7.063, 8.07436233, 8.68048572, 9.29834638, 9.96574599,
+            10.72080704, 11.52317465, 12.15094612, 18.65369516,
+            18.65389398] * u.mag
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_mag(pha_test), mag_test)
 
-    def test_ref(self):
-        themis = HG1G2(7.063*u.mag, 0.62*u.dimensionless_unscaled,
-                       0.14*u.dimensionless_unscaled, radius=100)
+    def test_to_ref(self):
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
+                wfb = 'V')
         pha_test = np.linspace(0, np.pi, 10)*u.rad
-        ref_test = np.array(
-            [2.14536381e-02, 8.45193252e-03, 4.83622683e-03,
-             2.73755213e-03, 1.48048003e-03, 7.38546998e-04,
-             3.52720817e-04, 1.97843827e-04, 4.95704528e-07,
-             4.95613763e-07])/u.sr
+        ref_test = [2.08689669e-02, 8.22159390e-03, 4.70442623e-03,
+                2.66294623e-03, 1.44013284e-03, 7.18419542e-04, 3.43108196e-04,
+                1.92452033e-04, 4.82195204e-07, 4.82106912e-07] / u.sr
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_ref(pha_test), ref_test)
 
@@ -420,18 +376,18 @@ class TestHG1G2:
 
 class TestHG12:
     def test_init(self):
-        themis = HG12(7.121, 0.68, radius=100*u.km, M_sun=-26.74)
+        themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
         assert themis._unit == 'mag'
         if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.radius, 100*u.km)
-        assert np.isclose(themis.M_sun, -26.74)
+            assert u.isclose(themis.radius, 100 * u.km)
         assert isinstance(themis.H, Parameter)
         assert np.isclose(themis.H.value, 7.121)
         assert isinstance(themis.G12, Parameter)
         assert np.isclose(themis.G12.value, 0.68)
+        assert themis.wfb == 'V'
 
     def test__G1_G2(self):
-        themis = HG12(7.121, 0.68, radius=100*u.km, M_sun=-26.74)
+        themis = HG12(7.121 * u.mag, 0.68)
         assert np.isclose(themis._G1, 0.669592)
         assert np.isclose(themis._G2, 0.1407)
 
@@ -459,31 +415,22 @@ class TestHG12:
             pha_test, 7.121, 0.68)), phi_test)
 
     def test_props(self):
-        themis = HG12(7.121, 0.68, radius=100)
-        assert np.isclose(themis.geomalb, 0.06389263856216909)
-        assert np.isclose(themis.bondalb, 0.02522850358089249)
-        assert np.isclose(themis.phaseint, 0.3948577512)
-        themis.radius = 100*u.km
-        if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.geomalb, 0.06389264 *
-                             u.dimensionless_unscaled)
-            assert u.isclose(themis.bondalb, 0.0252285 *
-                             u.dimensionless_unscaled)
+        themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
+        assert np.isclose(themis.geomalb, 0.06215139)
+        assert np.isclose(themis.bondalb, 0.02454096)
         assert np.isclose(themis.phaseint, 0.3948577512)
 
     def test_from_obs(self):
-        pha = np.array(
-            [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
+        pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
              31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
              63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
              94.73684211, 101.05263158, 107.36842105, 113.68421053,
-             120.]) * u.deg
-        data = np.array(
-            [6.95036472, 7.71609702, 8.04175457, 7.88226545, 8.28192813,
+             120.] * u.deg
+        data = [6.95036472, 7.71609702, 8.04175457, 7.88226545, 8.28192813,
              8.50954834, 8.36880691, 8.73216696, 8.90742914, 9.05696656,
              9.20869753, 9.52578025, 9.8427691, 9.91588852, 10.3636637,
              10.26459992, 10.79316978, 10.79202241, 11.36950747,
-             11.61018708]) * u.mag
+             11.61018708] * u.mag
         from astropy.modeling.fitting import LevMarLSQFitter
         fitter = LevMarLSQFitter()
         m = HG12.from_obs({'alpha': pha, 'mag': data}, fitter)
@@ -493,23 +440,21 @@ class TestHG12:
         assert isinstance(m.G12, Parameter) & np.isclose(
             m.G12.value, 0.44872) & (m.G12.unit == u.dimensionless_unscaled)
 
-    def test_mag(self):
+    def test_to_mag(self):
         pha_test = np.linspace(0, np.pi, 10) * u.rad
-        mag_test = np.array(
-          [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595, 10.72086969,
-          11.51208664, 12.12722017, 18.70628001, 18.70647883]) * u.mag
-        themis = HG12(7.121*u.mag, 0.68*u.dimensionless_unscaled, radius=100)
+        mag_test = [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595,
+                10.72086969, 11.51208664, 12.12722017, 18.70628001,
+                18.70647883] * u.mag
+        themis = HG12(7.121 * u.mag, 0.68)
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_mag(pha_test), mag_test)
 
-    def test_ref(self):
+    def test_to_ref(self):
         pha_test = np.linspace(0, np.pi, 10) * u.rad
-        ref_test = np.array(
-            [2.03376585e-02, 8.46621202e-03, 4.84325842e-03,
-             2.73492734e-03, 1.47717032e-03, 7.38504380e-04,
-             3.56341412e-04, 2.02214774e-04, 4.72268466e-07,
-             4.72181992e-07]) / u.sr
-        themis = HG12(7.121*u.mag, 0.68*u.dimensionless_unscaled, radius=100)
+        ref_test = [1.97834009e-02, 8.23548424e-03, 4.71126618e-03,
+            2.66039298e-03, 1.43691333e-03, 7.18378086e-04, 3.46630119e-04,
+            1.96703860e-04, 4.59397839e-07, 4.59313722e-07] / u.sr
+        themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_ref(pha_test), ref_test)
 
@@ -521,18 +466,19 @@ class TestHG12:
 
 class TestHG12_Pen16:
     def test_init(self):
-        themis = HG12_Pen16(7.121, 0.68, radius=100*u.km, M_sun=-26.74)
+        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
+            wfb = 'V')
         assert themis._unit == 'mag'
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.isclose(themis.radius, 100*u.km)
-        assert np.isclose(themis.M_sun, -26.74)
         assert isinstance(themis.H, Parameter)
         assert np.isclose(themis.H.value, 7.121)
         assert isinstance(themis.G12, Parameter)
         assert np.isclose(themis.G12.value, 0.68)
+        assert themis.wfb == 'V'
 
     def test__G1_G2(self):
-        themis = HG12_Pen16(7.121, 0.68, radius=100*u.km, M_sun=-26.74)
+        themis = HG12_Pen16(7.121 * u.mag, 0.68)
         assert np.isclose(themis._G1, 0.5731968132)
         assert np.isclose(themis._G2, 0.17124272)
 
@@ -559,31 +505,23 @@ class TestHG12_Pen16:
             pha_test, 7.121, 0.68)), phi_test)
 
     def test_props(self):
-        themis = HG12_Pen16(7.121, 0.68, radius=100)
-        assert np.isclose(themis.geomalb, 0.06389263856216909)
-        assert np.isclose(themis.bondalb, 0.024306474259348763)
-        assert np.isclose(themis.phaseint, 0.38042683486452)
-        themis.radius = 100*u.km
-        if LooseVersion(astropy.__version__) >= req_ver:
-            assert u.isclose(themis.geomalb, 0.06389264 *
-                             u.dimensionless_unscaled)
-            assert u.isclose(themis.bondalb, 0.02430647 *
-                             u.dimensionless_unscaled)
+        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
+                wfb = 'V')
+        assert np.isclose(themis.geomalb, 0.06215139)
+        assert np.isclose(themis.bondalb, 0.02364406)
         assert np.isclose(themis.phaseint, 0.38042683486452)
 
     def test_from_obs(self):
-        pha = np.array(
-            [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
+        pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
              31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
              63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
              94.73684211, 101.05263158, 107.36842105, 113.68421053,
-             120.]) * u.deg
-        data = np.array(
-            [7.15663893, 7.4389134, 8.00006177, 7.9044872, 8.16865497,
+             120.] * u.deg
+        data = [7.15663893, 7.4389134, 8.00006177, 7.9044872, 8.16865497,
              8.51010016, 8.63386712, 8.65893367, 8.84895152, 9.24495642,
              9.16195702, 9.54770054, 9.60599559, 10.06129054, 10.22544773,
              10.49122575, 10.78544483, 11.12145723, 11.18055954,
-             11.40468613]) * u.mag
+             11.40468613] * u.mag
         from astropy.modeling.fitting import LevMarLSQFitter
         fitter = LevMarLSQFitter()
         m = HG12_Pen16.from_obs({'alpha': pha, 'mag': data}, fitter)
@@ -593,24 +531,22 @@ class TestHG12_Pen16:
         assert isinstance(m.G12, Parameter) & np.isclose(
             m.G12.value, 0.631243) & (m.G12.unit == u.dimensionless_unscaled)
 
-    def test_mag(self):
+    def test_to_mag(self):
         pha_test = np.linspace(0, np.pi, 10) * u.rad
-        mag_test = np.array(
-          [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595, 10.72086969,
-           11.51208664, 12.12722017, 18.70628001, 18.70647883]) * u.mag
-        themis = HG12_Pen16(7.121*u.mag, 0.68 *
-                            u.dimensionless_unscaled, radius=100)
+        mag_test = [7.121, 8.07252953, 8.67890827, 9.2993879, 9.96817595,
+            10.72086969, 11.51208664, 12.12722017, 18.70628001,
+            18.70647883] * u.mag
+        themis = HG12_Pen16(7.121 * u.mag, 0.68)
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_mag(pha_test), mag_test)
 
-    def test_ref(self):
+    def test_to_ref(self):
         pha_test = np.linspace(0, np.pi, 10) * u.rad
-        ref_test = np.array(
-            [2.03376585e-02, 8.46621202e-03, 4.84325842e-03, 2.73492734e-03,
-             1.47717032e-03, 7.38504380e-04, 3.56341412e-04, 2.02214774e-04,
-             4.72268466e-07, 4.72181992e-07]) / u.sr
-        themis = HG12_Pen16(7.121*u.mag, 0.68 *
-                            u.dimensionless_unscaled, radius=100)
+        ref_test = [1.97834009e-02, 8.23548424e-03, 4.71126618e-03,
+            2.66039298e-03, 1.43691333e-03, 7.18378086e-04, 3.46630119e-04,
+            1.96703860e-04, 4.59397839e-07, 4.59313722e-07] / u.sr
+        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
+                wfb = 'V')
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_ref(pha_test), ref_test)
 

--- a/sbpy/photometry/tests/test_core.py
+++ b/sbpy/photometry/tests/test_core.py
@@ -12,12 +12,12 @@ from ...data import Ephem, Phys
 
 req_ver = LooseVersion('3.0.2')
 
-solar_fluxd.set({'V': -26.77 * u.mag})
 
 class TestLinear():
     def test_init(self):
+        solar_fluxd.set({'V': -26.77 * u.mag})
         linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
-                radius = 300 * u.km, wfb = 'V')
+                radius=300 * u.km, wfb='V')
         assert np.isclose(linphase.H.value, 5)
         assert linphase.H.unit == u.mag
         assert np.isclose(linphase.S.value, 0.04)
@@ -27,7 +27,7 @@ class TestLinear():
 
     def test_to_mag(self):
         linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
-                radius = 300 * u.km)
+                radius=300 * u.km)
         pha_test = np.linspace(0, np.pi, 10) * u.rad
         mag_test = [5., 5.8, 6.6, 7.4, 8.2, 9., 9.8, 10.6, 11.4, 12.2] * u.mag
         eph = linphase.to_mag(pha_test, append_results=True)
@@ -39,7 +39,7 @@ class TestLinear():
 
     def test_to_ref(self):
         linphase = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg,
-                radius = 300 * u.km, wfb = 'V')
+                radius=300 * u.km, wfb='V')
         pha_test = np.linspace(0, 180, 10) * u.deg
         eph = linphase.to_ref(pha_test, append_results=True)
         ref_test = [1.55045242e-02, 7.42093183e-03, 3.55188129e-03,
@@ -53,7 +53,7 @@ class TestLinear():
             assert u.allclose(eph['ref'], ref_test)
             assert u.allclose(eph['alpha'], pha_test)
         assert set(eph.field_names) == {'alpha', 'ref'}
-        eph_norm = linphase.to_ref(pha_test, normalized = 0 * u.deg,
+        eph_norm = linphase.to_ref(pha_test, normalized=0 * u.deg,
             append_results=True)
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(eph_norm['ref'], ref_norm_test)
@@ -62,7 +62,7 @@ class TestLinear():
 
     def test_props(self):
         linphase = LinearPhaseFunc(5 * u.mag, 2.29 * u.mag/u.rad,
-                radius = 300 * u.km, wfb = 'V')
+                radius=300 * u.km, wfb='V')
         assert np.isclose(linphase.geomalb, 0.0487089)
         assert np.isclose(linphase.bondalb, 0.01790315)
         assert np.isclose(linphase.phaseint, 0.36755394203990327)
@@ -83,7 +83,7 @@ class TestLinear():
 class TestHG:
     def test_init(self):
         # initialize with numbers
-        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        ceres = HG(3.34 * u.mag, 0.12, radius=480 * u.km, wfb='V')
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.isclose(ceres.radius, 480 * u.km)
         assert isinstance(ceres.H, Parameter)
@@ -108,7 +108,7 @@ class TestHG:
             m = HG.from_phys(phys)
 
     def test_to_phys(self):
-        m = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V',
+        m = HG(3.34 * u.mag, 0.12, radius=480 * u.km, wfb='V',
                 meta={'targetname': '1 Ceres'})
         p = m.to_phys()
         assert isinstance(p, Phys)
@@ -144,7 +144,7 @@ class TestHG:
         assert ceres._unit == 'mag'
 
     def test_props(self):
-        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        ceres = HG(3.34 * u.mag, 0.12, radius=480 * u.km, wfb='V')
         assert np.isclose(ceres.geomalb, 0.0877745)
         assert np.isclose(ceres.bondalb, 0.03198069)
         assert np.isclose(ceres.phaseint, 0.3643505755292945)
@@ -201,7 +201,7 @@ class TestHG:
         assert m.meta['fields'] == ['mag', 'mag1', 'mag2']
 
     def test_to_mag(self):
-        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        ceres = HG(3.34 * u.mag, 0.12, radius=480 * u.km, wfb='V')
         eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10) * u.rad,
                     'r': np.repeat(2.7*u.au, 10),
                     'delta': np.repeat(1.8*u.au, 10)}
@@ -230,7 +230,7 @@ class TestHG:
             assert u.allclose(mag4, mag2_test)
 
     def test_to_ref(self):
-        ceres = HG(3.34 * u.mag, 0.12, radius = 480 * u.km, wfb = 'V')
+        ceres = HG(3.34 * u.mag, 0.12, radius=480 * u.km, wfb='V')
         eph_dict = {'alpha': np.linspace(0, np.pi*0.9, 10)*u.rad,
                     'r': np.repeat(2.7*u.au, 10),
                     'delta': np.repeat(1.8*u.au, 10)}
@@ -266,8 +266,7 @@ class TestHG:
 class TestHG1G2:
     def test_init(self):
         # initialization with numbers
-        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
-                wfb = 'V')
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius=100 * u.km, wfb='V')
         assert themis._unit == 'mag'
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.isclose(themis.radius, 100 * u.km)
@@ -319,8 +318,7 @@ class TestHG1G2:
             pha_test, 7.063, 0.62, 0.14)), deriv_test)
 
     def test_props(self):
-        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
-                wfb = 'V')
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius=100 * u.km, wfb='V')
         assert np.isclose(themis.geomalb, 0.06556179)
         assert np.isclose(themis.bondalb, 0.02453008)
         assert np.isclose(themis.phaseint, 0.374152)
@@ -348,8 +346,7 @@ class TestHG1G2:
             m.G2.value, 0.17262569) & (m.G2.unit == u.dimensionless_unscaled)
 
     def test_to_mag(self):
-        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
-                wfb = 'V')
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius=100 * u.km, wfb='V')
         pha_test = np.linspace(0, np.pi, 10)*u.rad
         mag_test = [7.063, 8.07436233, 8.68048572, 9.29834638, 9.96574599,
             10.72080704, 11.52317465, 12.15094612, 18.65369516,
@@ -358,8 +355,7 @@ class TestHG1G2:
             assert u.allclose(themis.to_mag(pha_test), mag_test)
 
     def test_to_ref(self):
-        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius = 100 * u.km,
-                wfb = 'V')
+        themis = HG1G2(7.063 * u.mag, 0.62, 0.14, radius=100 * u.km, wfb='V')
         pha_test = np.linspace(0, np.pi, 10)*u.rad
         ref_test = [2.08689669e-02, 8.22159390e-03, 4.70442623e-03,
                 2.66294623e-03, 1.44013284e-03, 7.18419542e-04, 3.43108196e-04,
@@ -376,7 +372,7 @@ class TestHG1G2:
 
 class TestHG12:
     def test_init(self):
-        themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
+        themis = HG12(7.121 * u.mag, 0.68, radius=100 * u.km, wfb='V')
         assert themis._unit == 'mag'
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.isclose(themis.radius, 100 * u.km)
@@ -415,7 +411,7 @@ class TestHG12:
             pha_test, 7.121, 0.68)), phi_test)
 
     def test_props(self):
-        themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
+        themis = HG12(7.121 * u.mag, 0.68, radius=100 * u.km, wfb='V')
         assert np.isclose(themis.geomalb, 0.06215139)
         assert np.isclose(themis.bondalb, 0.02454096)
         assert np.isclose(themis.phaseint, 0.3948577512)
@@ -454,7 +450,7 @@ class TestHG12:
         ref_test = [1.97834009e-02, 8.23548424e-03, 4.71126618e-03,
             2.66039298e-03, 1.43691333e-03, 7.18378086e-04, 3.46630119e-04,
             1.96703860e-04, 4.59397839e-07, 4.59313722e-07] / u.sr
-        themis = HG12(7.121 * u.mag, 0.68, radius = 100 * u.km, wfb = 'V')
+        themis = HG12(7.121 * u.mag, 0.68, radius=100 * u.km, wfb='V')
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_ref(pha_test), ref_test)
 
@@ -466,8 +462,7 @@ class TestHG12:
 
 class TestHG12_Pen16:
     def test_init(self):
-        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
-            wfb = 'V')
+        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius=100 * u.km, wfb='V')
         assert themis._unit == 'mag'
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.isclose(themis.radius, 100*u.km)
@@ -505,8 +500,7 @@ class TestHG12_Pen16:
             pha_test, 7.121, 0.68)), phi_test)
 
     def test_props(self):
-        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
-                wfb = 'V')
+        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius=100 * u.km, wfb='V')
         assert np.isclose(themis.geomalb, 0.06215139)
         assert np.isclose(themis.bondalb, 0.02364406)
         assert np.isclose(themis.phaseint, 0.38042683486452)
@@ -545,8 +539,7 @@ class TestHG12_Pen16:
         ref_test = [1.97834009e-02, 8.23548424e-03, 4.71126618e-03,
             2.66039298e-03, 1.43691333e-03, 7.18378086e-04, 3.46630119e-04,
             1.96703860e-04, 4.59397839e-07, 4.59313722e-07] / u.sr
-        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius = 100 * u.km,
-                wfb = 'V')
+        themis = HG12_Pen16(7.121 * u.mag, 0.68, radius=100 * u.km, wfb='V')
         if LooseVersion(astropy.__version__) >= req_ver:
             assert u.allclose(themis.to_ref(pha_test), ref_test)
 


### PR DESCRIPTION
This PR makes use of the `sbpy.calib` system to support magnitude - reflectance conversion and deprecates `ref2mag` and `mag2ref`.