### PR TITLE
Fix version requirements for 0.2 branch.

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -4,9 +4,9 @@ channels:
     - astropy
 
 dependencies:
-    - python>=3 
-    - numpy     
-    - astropy
+    - python>=3.6
+    - numpy>=1.4.0
+    - astropy>=3.0<4.0
     - Cython
     - matplotlib
     - scipy
@@ -14,5 +14,5 @@ dependencies:
     - pip:
       - "git+https://github.com/astropy/astroquery.git"
       - ads
-      - synphot
+      - synphot>=0.1.2<0.2
       - sphinx-astropy

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
         - ADS_DEV_KEY=TjUyPHFOH48m5Katkeq0UCZQcejTg6bDbTuTGHxT
 
     matrix:
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - PIP_DEPENDENCIES='scipy astropy>=3.0<4.0 matplotlib ads synphot<0.2 https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
+        - PIP_DEPENDENCIES='scipy matplotlib ads synphot<0.2 https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
         - ADS_DEV_KEY=TjUyPHFOH48m5Katkeq0UCZQcejTg6bDbTuTGHxT
 
     matrix:
@@ -60,7 +60,7 @@ matrix:
         # Test docs and PEP8
         - os: linux
           stage: Test docs and PEP8
-          env: SETUP_CMD='build_docs -w' PIP_DEPENDENCIES="`echo $PIP_DEPENDENCIES sphinx-astropy`"
+          env: ASTROPY_VERSION=3 SETUP_CMD='build_docs -w' PIP_DEPENDENCIES="`echo $PIP_DEPENDENCIES sphinx-astropy`"
 
         - os: linux
           stage: Test docs and PEP8

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - PIP_DEPENDENCIES='scipy matplotlib ads synphot<0.2 https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
+        - PIP_DEPENDENCIES='scipy matplotlib ads synphot https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
         - ADS_DEV_KEY=TjUyPHFOH48m5Katkeq0UCZQcejTg6bDbTuTGHxT
 
     matrix:
@@ -69,7 +69,7 @@ matrix:
         # Remote data tests and coverage
         - os: linux
           stage: Remote data tests and coverage
-          env: DEBUG=True SETUP_CMD='test --coverage -R -V -a "--durations=50"' PYTEST_VERSION='<3.7'
+          env: DEBUG=True ASTROPY_VERSION=3 SYNPHOT_VERSION="0.1.*" SETUP_CMD='test --coverage -R -V -a "--durations=50"' PYTEST_VERSION='<3.7'
 
 install:
    - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - PIP_DEPENDENCIES='scipy matplotlib ads synphot https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
+        - PIP_DEPENDENCIES='scipy astropy>=3.0<4.0 matplotlib ads synphot<0.2 https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
         - ADS_DEV_KEY=TjUyPHFOH48m5Katkeq0UCZQcejTg6bDbTuTGHxT
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,14 +24,6 @@ environment:
       # CONDA_CHANNELS: "astropy-ci-extras astropy"
 
   matrix:
-
-      # We test Python 2.7 and 3.6 because 2.7 is the supported Python 2
-      # release of Astropy and Python 3.6 is the latest Python 3 release.
-
-      - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "stable"
-        NUMPY_VERSION: "stable"
-
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.4.0
+astropy>=3.0<4.0
 matplotlib
 ads
-synphot
+synphot<0.2
 git+git://github.com/astropy/astroquery.git@master#egg=astroquery

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(name=PACKAGENAME,
       scripts=scripts,
       install_requires=metadata.get(
           'install_requires', 'astropy').strip().split(','),
-      python_requires='>=3',
+      python_requires='>=3.6',
       include_package_data=True,
       author=AUTHOR,
       author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
I couldn't get it to work with astropy 4, so limiting to 3.x.  Also, synphot <0.2 to be safe.  openorb now requires python 3.6 or 3.7, so upping python to 3.6 (was 3.5).