### PR TITLE
better __getitem__ handling in data.DataClass

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
-0.3dev
+0.2.2dev
 ======
-
+- sbpy.data.DataClass.__getitem__ now always returns a new object of the same
+  class, unless a single field name is provided in which case an
+  astropy.Table.Column is returned.
 
 This changelog tracks changes to sbpy starting with version v0.2.
 

--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,8 @@
 ======
 - sbpy.data.DataClass.__getitem__ now always returns a new object of the same
   class, unless a single field name is provided in which case an
-  astropy.Table.Column is returned.
+  astropy.Table.Column (no units provided) or astropy.units.Quantity
+  (units provided) is returned.
 
 This changelog tracks changes to sbpy starting with version v0.2.
 

--- a/docs/sbpy/data/dataclass.rst
+++ b/docs/sbpy/data/dataclass.rst
@@ -300,7 +300,8 @@ Each of these columns can be accessed easily, for instance:
     [10.223423 10.233453 10.243452] deg
 
 which will return an `~astropy.units.quantity.Quantity` object if that
-column has a `~astropy.units.Unit` attached to it.
+column has a `~astropy.units.Unit` attached to it or a `~astropy.table.Column`
+otherwise.
 
 Similarly, if you are interested in the first set of observations in
 ``obs``, you can use:
@@ -311,7 +312,8 @@ Similarly, if you are interested in the first set of observations in
     --------- --------- ------------
     10.223423 -12.42123 2451523.6234
 
-which returns you a table with only the requested subset of the
+which returns you a new instance of the same class as your original
+objet with only the requested subset of the
 data. In order to retrieve RA from the second observation, you can
 combine both examples and do:
 
@@ -331,6 +333,13 @@ for instance:
     10.223423 -12.42123
     10.233453 -12.41562
     10.243452 -12.40435
+
+    >>> obs[:2] # doctest: +SKIP
+        ra       dec         t
+       deg       deg         d
+    --------- --------- ------------
+    10.223423 -12.42123 2451523.6234
+    10.233453 -12.41562 2451523.7345
 
     >>> obs[obs['ra'] <= 10.233453*u.deg] # doctest: +SKIP
         ra       dec         t

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -614,17 +614,20 @@ class DataClass():
 
     def __getitem__(self, ident):
         """Return columns or rows from data table(``self._table``); checks
-        for and may use alternative field names."""
+        for and may use alternative field names. This method will always return
+        an instance of __class__, except in the case when a field name is
+        requested (then return a Table column)."""
 
+        # ignore slices
+        if isinstance(ident, slice):
+            pass
         # iterable
-        if isinstance(ident, (list, tuple, ndarray)):
+        elif isinstance(ident, (list, tuple, ndarray)):
             if all([isinstance(i, str) for i in ident]):
                 # list of column names
                 self = self._convert_columns(ident)
                 newkeylist = [self._translate_columns(i)[0] for i in ident]
                 ident = newkeylist
-                # return as new DataClass object
-                return self.from_table(self._table[ident])
             # ignore lists of boolean (masks)
             elif all([isinstance(i, bool) for i in ident]):
                 pass
@@ -635,11 +638,12 @@ class DataClass():
         elif isinstance(ident, str):
             self = self._convert_columns(ident)
             ident = self._translate_columns(ident)[0]
+            return self._table[ident]
         elif isinstance(ident, int):
-            return self.from_table(self._table[ident])
+            pass
 
-        # return as element from self_table
-        return self._table[ident]
+        # return as new instance of this class
+        return self.from_table(self._table[ident])
 
     def __setitem__(self, *args):
         """Refer cls.__setitem__ to self._table"""

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -616,33 +616,28 @@ class DataClass():
         """Return columns or rows from data table(``self._table``); checks
         for and may use alternative field names. This method will always return
         an instance of __class__, except in the case when a field name is
-        requested (then return a Table column)."""
+        requested (then return an `astropy.table.Column` if no units are
+        provided or a `astropy.units.Quantity` if units are provided)."""
 
-        # ignore slices
-        if isinstance(ident, slice):
-            pass
-        # iterable
-        elif isinstance(ident, (list, tuple, ndarray)):
-            if all([isinstance(i, str) for i in ident]):
-                # list of column names
+        # slices, iterables consisting of booleans and integers, and integer
+        # indices are all treated in the same way and are required to return
+        # a new __class__ object; only have to treat string identifiers
+        # separately in that those have to be checked for conversions
+        # and translations
+
+        # list of field names
+        if (isinstance(ident, (list, tuple, ndarray)) and
+            all([isinstance(i, str) for i in ident])):
                 self = self._convert_columns(ident)
                 newkeylist = [self._translate_columns(i)[0] for i in ident]
                 ident = newkeylist
-            # ignore lists of boolean (masks)
-            elif all([isinstance(i, bool) for i in ident]):
-                pass
-            # ignore lists of integers
-            elif all([isinstance(i, int) for i in ident]):
-                pass
-        # individual strings
+        # individual field names
         elif isinstance(ident, str):
             self = self._convert_columns(ident)
             ident = self._translate_columns(ident)[0]
             return self._table[ident]
-        elif isinstance(ident, int):
-            pass
 
-        # return as new instance of this class
+        # return as new instance of this class for all other identifiers
         return self.from_table(self._table[ident])
 
     def __setitem__(self, *args):

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -5,7 +5,7 @@ import pytest
 from copy import deepcopy
 from numpy import array
 import astropy.units as u
-from astropy.table import QTable
+from astropy.table import QTable, Column
 from ..core import DataClass, conf, DataClassError
 
 
@@ -261,16 +261,25 @@ def test_get_set():
                      ('c', [7, 8, 8]))))
 
     # get a single column
-    assert len(data['a']) == 3
+    x = data['a']
+    assert len(x) == 3
+    assert isinstance(x, Column)
+
+    # get a list of columns
+    x = data[['a', 'c']]
+    assert len(x.field_names) == 2
+    assert isinstance(x, DataClass)
 
     # mask rows
     masked = data[[True, False, False]]
     assert len(masked) == 1
     assert masked['b'][0] == 4
+    assert isinstance(masked, DataClass)
 
     # get list of rows
     shortened = data[[0, 1]]
     assert len(shortened) == 2
+    assert isinstance(shortened, DataClass)
 
     # modify an existing column
     data['a'][:] = [0, 0, 0]
@@ -282,10 +291,12 @@ def test_get_set():
     # add non-existing column using set
     data['z'] = 3
     assert len(data['z'] == 3)
+    assert isinstance(data, DataClass)
 
     # modify existing column using set
     data['z'] = 2
     assert data['z'][1] == 2
+    assert isinstance(data, DataClass)
 
 
 def test_units():

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -257,13 +257,16 @@ def test_get_set():
 
     data = DataClass.from_dict(
         OrderedDict((('a', [1, 2, 3]),
-                     ('b', [4, 5, 6]),
+                     ('b', [4, 5, 6]*u.m),
                      ('c', [7, 8, 8]))))
 
     # get a single column
     x = data['a']
     assert len(x) == 3
     assert isinstance(x, Column)
+    x = data['b']
+    assert len(x) == 3
+    assert isinstance(x, u.Quantity)
 
     # get a list of columns
     x = data[['a', 'c']]
@@ -273,11 +276,20 @@ def test_get_set():
     # mask rows
     masked = data[[True, False, False]]
     assert len(masked) == 1
-    assert masked['b'][0] == 4
+    assert masked['b'][0] == 4*u.m
     assert isinstance(masked, DataClass)
+
+    # get single row
+    shortened = data[1]
+    assert shortened['a'] == 2
+    assert isinstance(shortened, DataClass)
 
     # get list of rows
     shortened = data[[0, 1]]
+    assert len(shortened) == 2
+    assert isinstance(shortened, DataClass)
+
+    # get slice
     assert len(shortened) == 2
     assert isinstance(shortened, DataClass)
 


### PR DESCRIPTION
Currently, slicing and some other `__getitem__` calls on `DataClass` objects return `astropy.table.QTable` instances instead of objects of the same class. This commit fixes this behavior in the following way:
* if a single field name is requested (e.g., `data['RA']`), an `astropy.table.Column` object is returned (as if the method is applied to a table);
* in any other case, the method returns an instance of the same class as the current instance.