### PR TITLE
Do not require any returned columns from JPL Horizons, except time.

### DIFF
--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -195,7 +195,8 @@ class Ephem(DataClass):
                                        scale='ut1', format='jd').utc.jd
         all_eph['epoch'] = Time(all_eph['datetime_jd'], format='jd',
                                 scale='utc')
-        all_eph['siderealtime'].unit = u.Unit('hour')
+        if 'siderealtime' in all_eph.colnames:
+            all_eph['siderealtime'].unit = u.Unit('hour')
 
         all_eph.remove_column('datetime_jd')
         all_eph.remove_column('datetime_str')

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -110,7 +110,7 @@ class TestEphemFromHorizons:
     def test_minimum_working_columns(self):
         """Avoid assuming any particular columns are returned.
 
-        Regression test for #xxx.
+        Regression test for #242.
 
         """
         e = Ephem.from_horizons(1, quantities='1')  # just RA, Dec

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -107,6 +107,17 @@ class TestEphemFromHorizons:
         except IERSRangeError:
             pass
 
+    def test_minimum_working_columns(self):
+        """Avoid assuming any particular columns are returned.
+
+        Regression test for #xxx.
+
+        """
+        e = Ephem.from_horizons(1, quantities='1')  # just RA, Dec
+        assert len(e) == 1
+        e = Ephem.from_horizons(1, quantities='19')  # just rh and delta-rh
+        assert len(e) == 1
+
 
 @pytest.mark.remote_data
 class TestEphemFromMPC:


### PR DESCRIPTION
Ephem.from_horizons crashes when 'siderealtime' isn't present in the returned table.  It isn't a required column, so I avoid the error with an if statement.  I am adding a test to avoid similar errors in the future.