### PR TITLE
Fix some issues in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 
-language: minimal
+language: shell
 
 os:
     - linux
-
-sudo: false
 
 # The apt packages below are needed for sphinx builds. A full list of
 # packages that can be included can be found here:
@@ -21,8 +19,6 @@ stages:
    - name: Test docs and PEP8
    - name: Remote data tests and coverage
 
-stage: Build tests
-
 # setting up environment variables and the build matrix
 env:
     global:
@@ -33,14 +29,14 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - PIP_DEPENDENCIES='scipy matplotlib ads synphot https://github.com/astropy/astroquery/archive/master.zip pytest-astropy codecov'
+        - PIP_DEPENDENCIES='scipy matplotlib ads synphot astroquery pytest-astropy codecov'
         - ADS_DEV_KEY=TjUyPHFOH48m5Katkeq0UCZQcejTg6bDbTuTGHxT
 
-    matrix:
+    jobs:
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
-matrix:
+jobs:
 
     # Don't wait for allowed failures
     fast_finish: true
@@ -59,8 +55,9 @@ matrix:
 
         # Test docs and PEP8
         - os: linux
+          dist: bionic
           stage: Test docs and PEP8
-          env: ASTROPY_VERSION=3 SETUP_CMD='build_docs -w' PIP_DEPENDENCIES="`echo $PIP_DEPENDENCIES sphinx-astropy`"
+          env: ASTROPY_VERSION=3 SETUP_CMD='build_docs -w' PIP_DEPENDENCIES="`echo $PIP_DEPENDENCIES https://github.com/astropy/sphinx-automodapi/archive/master.zip sphinx-astropy`"
 
         - os: linux
           stage: Test docs and PEP8


### PR DESCRIPTION
The Travis error appears to be a `sphinx-automodapi` bug that has been fixed recently (https://github.com/astropy/sphinx-automodapi/commit/40245cabf9ec19da4b44650f998d0e543a45b6fb#diff-978178d3cc50e124fcd1ddfec944ca29 ). Let's see if building the docs with the latest sphinx-automodapi will fix the error.

``` python
WARNING: file looks like ECSV format but PyYAML is not installed so it cannot be parsed as ECSV [astropy.io.ascii.ecsv]
WARNING: Source spectrum is tapered. [synphot.observation]
WARNING: Source spectrum is tapered. [synphot.observation]
reading sources... [100%] status                                               
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  5%] api/sbpy.activity.GaussianAperture                    
Exception occurred:
  File "/home/travis/miniconda/envs/test/lib/python3.7/site-packages/docutils/nodes.py", line 625, in __getitem__
    return self.attributes[key]
KeyError: 'refexplicit'
The full traceback has been saved in /tmp/sphinx-err-ps4l9bfe.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
Sphinx Documentation subprocess failed with return code 2
The command "$MAIN_CMD $SETUP_CMD" exited with 2.
```

A few other changes in the travis config file are listed below:

* minimal is an alias for `shell`
* remove deprecated key `sudo` (does not have any effect))
* remove unknown key `stage`
* installing astroquery 0.4 from pypi should be fine now
