### PR TITLE
Remove example entry point from package template

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,8 +62,3 @@ ignore = E402,E741,E226,E501
 # Excluding files that are directly copied from the package template or
 # generated
 exclude = _astropy_init.py,version.py,ah_bootstrap.py
-
-
-[entry_points]
-
-astropy-package-template-example = packagename.example_mod:main


### PR DESCRIPTION
There is an entry defined in `setup.cfg` that is left over from the astropy package template. This removes that entry point.