### PR TITLE
bugfix in `sbpy.photometry`

### DIFF
--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -1026,6 +1026,8 @@ class HG1G2(HG12BaseClass):
 
     @staticmethod
     def evaluate(ph, h, g1, g2):
+        if isinstance(ph, u.Quantity):
+            ph = ph.to('rad').value
         func = g1*HG1G2._phi1(ph)+g2*HG1G2._phi2(ph)+(1-g1-g2)*HG1G2._phi3(ph)
         if isinstance(func, u.Quantity):
             func = func.value


### PR DESCRIPTION
Replace PR #283

Fix different results between model evaluation and direct call to .evaluate method for photometry models
