### PR TITLE
Add spectral reddening

### DIFF
--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -58,6 +58,56 @@ Renormalize to 1.0 μm:
   <SpectralGradient 6.89655172 % / 100 nm>
 
 
+Spectral Reddening
+------------------
+
+Linear spectral reddening is enabled by class `~sbpy.spectroscopy.Reddening`,
+which is based on `~synphot.BaseUnitlessSpectrum`.
+
+Initialize a `~sbpy.spectroscopy.Reddening` class from a spectral gradient:
+
+
+.. plot::
+  :include-source: True
+
+  import matplotlib.pyplot as plt
+  import astropy.units as u
+  from sbpy.spectroscopy import SpectralGradient, Reddening
+  from sbpy.units import hundred_nm
+
+  S = SpectralGradient(10 * u.percent / hundred_nm, wave0=0.55 * u.um)
+  linear_reddening = Reddening(S)
+  linear_reddening.plot()
+  plt.gca().grid()
+
+
+This class can then be used to linearly redden a spectrum as a
+`~synphot.SourceSpectrum` class instance:
+
+
+.. plot::
+  :include-source: True
+
+  import numpy as np
+  import matplotlib.pyplot as plt
+  import astropy.units as u
+  from synphot import SourceSpectrum
+  from synphot.models import BlackBodyNorm1D
+  from sbpy.spectroscopy import SpectralGradient, Reddening
+  from sbpy.units import hundred_nm
+
+  S = SpectralGradient(10 * u.percent / hundred_nm, wave0=0.55 * u.um)
+  linear_reddening = Reddening(S)
+  spec = SourceSpectrum(BlackBodyNorm1D, temperature=5500 * u.K)
+  reddened = spec * linear_reddening
+  wv = np.linspace(0.3, 1, 100) * u.um
+
+  plt.plot(wv, spec(wv))
+  plt.plot(wv, reddened(wv))
+  plt.legend(['Original', 'Reddened'])
+  plt.setp(plt.gca(), xlabel='Wavelength (um)', ylabel='Flux (PHOTLAM)')
+  plt.tight_layout()
+
 
 Reference/API
 -------------

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -62,7 +62,7 @@ Spectral Reddening
 ------------------
 
 Linear spectral reddening is enabled by class `~sbpy.spectroscopy.Reddening`,
-which is based on `~synphot.BaseUnitlessSpectrum`.
+which is based on `~synphot.spectrum.BaseUnitlessSpectrum`.
 
 Initialize a `~sbpy.spectroscopy.Reddening` class from a spectral gradient:
 
@@ -106,6 +106,34 @@ This class can then be used to linearly redden a spectrum as a
   plt.plot(wv, reddened(wv))
   plt.legend(['Original', 'Reddened'])
   plt.setp(plt.gca(), xlabel='Wavelength (um)', ylabel='Flux (PHOTLAM)')
+  plt.tight_layout()
+
+``sbpy`` ``SpectralSource`` objects have a ``redden()`` method for reddening.
+The following example reddens a solar spectrum:
+
+
+.. plot::
+  :include-source: True
+
+  import numpy as np
+  import matplotlib.pyplot as plt
+  import astropy.units as u
+  from sbpy.calib import Sun
+  from sbpy.spectroscopy import SpectralGradient
+  from sbpy.units import hundred_nm
+
+  sun = Sun.from_builtin('E490_2014LR') # low-resolution solar spectrum
+  S = SpectralGradient(10 * u.percent / hundred_nm, wave0=0.55 * u.um)
+  red_sun = sun.redden(S)
+
+  wv = np.linspace(0.3, 1, 100) * u.um
+  fluxd_unit = u.Unit('W/(m2 um)')
+
+  plt.plot(wv, sun.observe(wv, unit=fluxd_unit))
+  plt.plot(wv, red_sun.observe(wv, unit=fluxd_unit))
+  plt.legend(['Original', 'Reddened'])
+  plt.setp(plt.gca(), xlabel='Wavelength (um)',
+      ylabel='Flux density ({})'.format(fluxd_unit))
   plt.tight_layout()
 
 

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -485,6 +485,9 @@ class SpectralSource(ABC):
         from copy import deepcopy
         red_spec = deepcopy(self)
         red_spec._source = red_spec.source * r
+        if red_spec.description is not None:
+            red_spec._description = '{} reddened by {} at {}'.format(
+                    red_spec.description, S, S.wave0)
         return red_spec
 
 

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -28,7 +28,6 @@ except ImportError:
 
 from ..exceptions import SbpyException
 from .. import bib
-from ..units import hundred_nm
 
 __doctest_requires__ = {
     'SpectralSource': ['synphot'],

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -531,7 +531,7 @@ class Reddening(BaseUnitlessSpectrum):
     S : `~SpectralGradient`
         The spectral gradient to redden.
     """
-    @u.quantity_input(S = u.percent / u.um)
+    @u.quantity_input(S=u.percent / u.um)
     def __init__(self, S):
         if getattr(S, 'wave0', None) is None:
             raise ValueError("Normalization wavelength in `S` (.wave0) is "

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -481,8 +481,8 @@ class SpectralSource(ABC):
             Reddened spectrum
 
         """
-        r = Reddening(S)
         from copy import deepcopy
+        r = Reddening(S)
         red_spec = deepcopy(self)
         red_spec._source = red_spec.source * r
         if red_spec.description is not None:
@@ -531,7 +531,11 @@ class Reddening(BaseUnitlessSpectrum):
     S : `~SpectralGradient`
         The spectral gradient to redden.
     """
+    @u.quantity_input(S = u.percent / u.um)
     def __init__(self, S):
+        if getattr(S, 'wave0', None) is None:
+            raise ValueError("Normalization wavelength in `S` (.wave0) is "
+                "required by not available.")
         wv = [1, 2] * S.wave0
         df = (S.wave0 * S).to('').value
         super().__init__(

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -521,7 +521,6 @@ class BlackbodySource(SpectralSource):
         return self._T
 
 
-
 class Reddening(BaseUnitlessSpectrum):
     """Class to handle simple linear reddening.
 

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -65,9 +65,13 @@ class TestSpectralSource:
 
     def test_redden(self):
         s = Star()
+        s._description = 'Test star spectrum'
         S = SpectralGradient(14 * u.percent / hundred_nm, wave0=0.55 * u.um)
         s_r = s.redden(S)
         assert u.isclose(s_r(0.65 * u.um), 1.14 * u.W / (u.m**2 * u.um))
+        assert s_r.description == 'Test star spectrum reddened by {} at {}'. \
+                    format(14 * u.percent / hundred_nm, 0.55 * u.um)
+
 
 class TestBlackbodySource:
     @pytest.mark.parametrize('T', (

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -10,9 +10,11 @@ import astropy.constants as const
 import synphot
 from .. import sources
 from ..sources import (BlackbodySource, SinglePointSpectrumError,
-                       SpectralSource, SynphotRequired)
+                       SpectralSource, SynphotRequired, Reddening)
+from ..core import SpectralGradient
 from ... import bib, units
 from ...photometry import bandpass
+from ...units import hundred_nm
 
 V = bandpass('johnson v')
 I = bandpass('cousins i')
@@ -61,6 +63,11 @@ class TestSpectralSource:
         with pytest.raises(TypeError):
             s.color_index(np.arange(2), unit=u.ABmag)
 
+    def test_redden(self):
+        s = Star()
+        S = SpectralGradient(14 * u.percent / hundred_nm, wave0=0.55 * u.um)
+        s_r = s.redden(S)
+        assert u.isclose(s_r(0.65 * u.um), 1.14 * u.W / (u.m**2 * u.um))
 
 class TestBlackbodySource:
     @pytest.mark.parametrize('T', (
@@ -91,3 +98,13 @@ class TestBlackbodySource:
         BB = BlackbodySource(300 * u.K)
         test = BB(w, unit=f.unit).value
         assert np.allclose(test, f.value)
+
+
+
+class TestReddening:
+    def test_init(self):
+        S = SpectralGradient(14 * u.percent / hundred_nm, wave0=0.55 * u.um)
+        r = Reddening(S)
+        assert np.isclose(r(0.45 * u.um), 1 - 0.14)
+        assert np.isclose(r(0.55 * u.um), 1.)
+        assert np.isclose(r(0.65 * u.um), 1 + 0.14)

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -100,7 +100,6 @@ class TestBlackbodySource:
         assert np.allclose(test, f.value)
 
 
-
 class TestReddening:
     def test_init(self):
         S = SpectralGradient(14 * u.percent / hundred_nm, wave0=0.55 * u.um)

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -111,3 +111,10 @@ class TestReddening:
         assert np.isclose(r(0.45 * u.um), 1 - 0.14)
         assert np.isclose(r(0.55 * u.um), 1.)
         assert np.isclose(r(0.65 * u.um), 1 + 0.14)
+        # test exception
+        S = SpectralGradient(14 * u.percent / hundred_nm)
+        with pytest.raises(ValueError):
+            r = Reddening(S)
+        # test quantity input
+        with pytest.raises(u.UnitsError):
+            r = Reddening(14 * u.percent)


### PR DESCRIPTION
This PR replaces #281 

Add spectral reddening functionality to `sbpy.spectroscopy.SpectralSource` class
