### PR TITLE
Remove jplhorizons server

### DIFF
--- a/sbpy/spectroscopy/core.py
+++ b/sbpy/spectroscopy/core.py
@@ -22,8 +22,6 @@ except ImportError:
         pass
 
 
-conf.horizons_server = 'https://ssd.jpl.nasa.gov/horizons_batch.cgi'
-
 __all__ = ['Spectrum', 'SpectralModel', 'SpectralGradient']
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -87,9 +87,9 @@ extras =
 
 commands =
     pip freeze
-    !cov-!remote: pytest --pyargs sbpy {toxinidir}/docs --remote-data {env:MPLFLAGS} {posargs}
+    !cov-!remote: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     !cov-remote: pytest --pyargs sbpy {toxinidir}/docs --remote-data {env:MPLFLAGS} {posargs}
-    cov-!remote: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} --cov sbpy --cov-config={toxinidir}/setup.cfg --remote-data {posargs}
+    cov-!remote: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} --cov sbpy --cov-config={toxinidir}/setup.cfg {posargs}
     cov-remote: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} --cov sbpy --cov-config={toxinidir}/setup.cfg --remote-data {posargs}
 
 [testenv:build_docs]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy116,-numpy117,-numpy118}{,-cov}
+    py{36,37,38,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy116,-numpy117,-numpy118}{,-cov}{,-remote}
     build_docs
     linkcheck
     codestyle
@@ -45,6 +45,7 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
+    remote: and run remote tests
     numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
@@ -86,8 +87,10 @@ extras =
 
 commands =
     pip freeze
-    !cov: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} {posargs}
-    cov: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} --cov sbpy --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov-!remote: pytest --pyargs sbpy {toxinidir}/docs --remote-data {env:MPLFLAGS} {posargs}
+    !cov-remote: pytest --pyargs sbpy {toxinidir}/docs --remote-data {env:MPLFLAGS} {posargs}
+    cov-!remote: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} --cov sbpy --cov-config={toxinidir}/setup.cfg --remote-data {posargs}
+    cov-remote: pytest --pyargs sbpy {toxinidir}/docs {env:MPLFLAGS} --cov sbpy --cov-config={toxinidir}/setup.cfg --remote-data {posargs}
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
The spectroscopy submodule overrides astroquery's URL for JPL Horizons.  This will break on Sep 27, when the old API URL is removed.

When the astroquery update with the new API URL is available, I will update the sbpy requirements.