### PR TITLE
Switch pyoorb-experiment back to main branch.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 
     # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160 (takes too long)
     alldeps: pytest-openfiles==0.4.0
-    alldeps: git+https://github.com/mkelley/pyoorb-experiment.git@sbpy-testing#egg=pyoorb
+    alldeps: git+https://github.com/mkelley/pyoorb-experiment.git#egg=pyoorb
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.


### PR DESCRIPTION
We run too many tests to support the full DE430 ephemeris in git LFS.