### PR TITLE
Restore use of sbpy-testing branch of pyoorb-experiment repo.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps =
 
     # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160 (takes too long)
     alldeps: pytest-openfiles==0.4.0
-    alldeps: git+https://github.com/mkelley/pyoorb-experiment.git#egg=pyoorb
+    alldeps: git+https://github.com/mkelley/pyoorb-experiment.git@sbpy-testing#egg=pyoorb
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version.


### PR DESCRIPTION
I checked in a short DE430 ephemeris to pyoorb-experiment's sbpy-testing branch.  The file covers 1990 to 2030 and is 3.6 MB.  Using this is preferred over building the full 100 MB DE430 ephemeris from JPL-hosted data files in our github actions CI.