### PR TITLE
Fix linkcheck 20220111

### DIFF
--- a/docs/sbpy/data/dataclass.rst
+++ b/docs/sbpy/data/dataclass.rst
@@ -576,7 +576,15 @@ Writing object data to a file
 `~sbpy.data.DataClass` objects can be written to files using
 `~sbpy.data.DataClass.to_file`:
 
-    >>> obs.to_file('observations.dat')  # doctest: +SKIP
+    .. testsetup:: obs.to_file
+        >>> import os
+        >>> assert not os.path.exists('observations.dat')
+
+    .. doctest:: obs.to_file
+        >>> obs.to_file('observations.dat')
+
+    .. testcleanup:: obs.to_file
+        >>> os.unlink('observations.dat')
 
 By default, the data are written in ASCII format, but other formats
 are available, too (`list of file formats

--- a/docs/sbpy/data/dataclass.rst
+++ b/docs/sbpy/data/dataclass.rst
@@ -576,7 +576,7 @@ Writing object data to a file
 `~sbpy.data.DataClass` objects can be written to files using
 `~sbpy.data.DataClass.to_file`:
 
-    >>> obs.to_file('observations.dat')
+    >>> obs.to_file('observations.dat')  # doctest: +SKIP
 
 By default, the data are written in ASCII format, but other formats
 are available, too (`list of file formats

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -184,7 +184,7 @@ class DustComaQuantity(u.SpecificTypeQuantity,
     _equivalent_unit = u.meter
     _include_easy_conversion_members = False
 
-    def __new__(cls, value, unit=None, dtype=None, copy=None):
+    def __new__(cls, value, unit=None, dtype=None, copy=True):
         return super().__new__(cls, value, unit=unit, dtype=dtype,
                                copy=copy)
 

--- a/sbpy/spectroscopy/core.py
+++ b/sbpy/spectroscopy/core.py
@@ -98,7 +98,7 @@ class SpectralGradient(u.SpecificTypeQuantity):
     _include_easy_conversion_members = False
 
     def __new__(cls, value, unit=None, wave=None, wave0=None,
-                dtype=None, copy=None):
+                dtype=None, copy=True):
         S = super().__new__(cls, value, unit=unit, dtype=dtype,
                             copy=copy)
 


### PR DESCRIPTION
Address failing weekly test:

```
Warning, treated as error:
/home/runner/work/sbpy/sbpy/docs/sbpy/spectroscopy/index.rst:70:Exception occurred in plotting index-1
 from /home/runner/work/sbpy/sbpy/docs/sbpy/spectroscopy/index.rst:
Traceback (most recent call last):
  File "/home/runner/work/sbpy/sbpy/.tox/linkcheck/lib/python3.8/site-packages/matplotlib/sphinxext/plot_directive.py", line 517, in _run_code
    exec(code, ns)
  File "<string>", line 6, in <module>
  File "/home/runner/work/sbpy/sbpy/.tox/linkcheck/lib/python3.8/site-packages/sbpy/spectroscopy/core.py", line 102, in __new__
    S = super().__new__(cls, value, unit=unit, dtype=dtype,
  File "/home/runner/work/sbpy/sbpy/.tox/linkcheck/lib/python3.8/site-packages/astropy/units/quantity.py", line 430, in __new__
    return np.array(value, dtype=dtype, copy=copy, order=order,
ValueError: NoneType copy mode not allowed.
```

And, catch an issue when doctests are run twice in a row.  obs.to_file example writes a file, but raises an error when the file already exists.