### PR TITLE
Fix remote tests and from_mpc bugs

### DIFF
--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -94,7 +94,7 @@ model parameters:
        H    G 
       mag
       ---- ----
-      3.53 0.12
+      3.54 0.12
 
 Note that model set is not supported.  Only one model can be initialized with
 the first set of valid parameters in the input `~sbpy.data.DataClass`.

--- a/sbpy/activity/gas/productionrate.py
+++ b/sbpy/activity/gas/productionrate.py
@@ -11,6 +11,7 @@ created on June 26, 2019
 
 import tempfile
 import numpy as np
+import astropy
 import astropy.constants as con
 import astropy.units as u
 from astroquery.jplspec import JPLSpec
@@ -21,6 +22,9 @@ from ...data import Phys
 __all__ = ['LTE', 'NonLTE', 'einstein_coeff',
            'intensity_conversion', 'beta_factor', 'total_number',
            'from_Haser']
+
+if astropy.__version__ < '5':
+    __doctest_skip__ = ['LTE.from_Drahus']
 
 
 def intensity_conversion(mol_data):
@@ -489,7 +493,8 @@ class LTE():
         if not isinstance(mol_data, Phys):
             raise ValueError('mol_data must be a `sbpy.data.phys` instance.')
 
-        register('Spectroscopy', {'Total Number (eq. 10)': '2004come.book..391B'})
+        register('Spectroscopy', {
+                 'Total Number (eq. 10)': '2004come.book..391B'})
 
         cdensity = (8*np.pi*con.k_B*mol_data['t_freq'][0]**2 /
                     (con.h*con.c**3 * mol_data['eincoeff'][0])).decompose()
@@ -590,7 +595,7 @@ class LTE():
         ...                     ephemobj, vgas, aper, b=b) # doctest: +REMOTE_DATA
 
         >>> q  # doctest: +REMOTE_DATA +FLOAT_CMP
-        <Quantity 1.09899965e+25 1 / s>
+        <MaskedQuantity 1.09899965e+25 1 / s>
 
 
         References
@@ -847,11 +852,13 @@ class NonLTE():
 
         fluxes = np.array(fluxes)
 
-        index_flux = (np.abs(fluxes-integrated_flux.to(u.K * u.km / u.s).value)).argmin()
+        index_flux = (
+            np.abs(fluxes-integrated_flux.to(u.K * u.km / u.s).value)).argmin()
 
         # corresponding column density in 1/cm^2
         column_density = column_density[index_flux]
-        print('Closest Integrated Flux:{}'.format(fluxes[index_flux] * u.K * u.km / u.s))
+        print('Closest Integrated Flux:{}'.format(
+            fluxes[index_flux] * u.K * u.km / u.s))
         print('Given Integrated Flux: {}'.format(integrated_flux))
 
         return column_density

--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -406,18 +406,18 @@ class Ephem(DataClass):
                 if start is None:
                     eph = []
                     for i in range(len(_epochs)):
-                        e = MPC.get_ephemeris(targetid, location=location,
-                                              start=Time(_epochs[i],
-                                                         scale='utc'),
-                                              number=1, **kwargs)
+                        e = MPC().get_ephemeris(targetid, location=location,
+                                                start=Time(_epochs[i],
+                                                           scale='utc'),
+                                                number=1, **kwargs)
                         e['Date'] = e['Date'].iso  # for vstack to work
                         eph.append(e)
                     eph = QTable(vstack(eph))
                     eph['Date'] = Time(eph['Date'], scale='utc')
                 else:
-                    eph = MPC.get_ephemeris(targetid, location=location,
-                                            start=start, step=step,
-                                            number=number, **kwargs)
+                    eph = MPC().get_ephemeris(targetid, location=location,
+                                              start=start, step=step,
+                                              number=number, **kwargs)
             except InvalidQueryError as e:
                 raise QueryError(
                     'Error raised by astroquery.mpc: {:s}'.format(str(e)))

--- a/sbpy/data/obs.py
+++ b/sbpy/data/obs.py
@@ -82,8 +82,8 @@ class Obs(Ephem):
                 id_type += ' designation'
 
         try:
-            results = MPC.get_observations(targetid, id_type=id_type,
-                                           **kwargs)
+            results = MPC().get_observations(targetid, id_type=id_type,
+                                             **kwargs)
         except (RuntimeError, ValueError) as e:
             raise QueryError(
                 ('Error raised by '

--- a/sbpy/data/orbit.py
+++ b/sbpy/data/orbit.py
@@ -273,7 +273,7 @@ class Orbit(DataClass):
 
             # get elements
             kwargs[id_type] = targetid
-            e = MPC.query_object(target_type, **kwargs)
+            e = MPC().query_object(target_type, **kwargs)
 
             # parse results from MPC.query_object
             results = {}

--- a/sbpy/data/tests/test_obs_remote.py
+++ b/sbpy/data/tests/test_obs_remote.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from numpy.testing import assert_allclose
 from astropy.time import Time
 import astropy.units as u
 

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -149,7 +149,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
     >>>
     >>> # Initialize from physical parameters pulled from JPL SBDB
     >>> phys = Phys.from_sbdb('Ceres')       # doctest: +REMOTE_DATA
-    >>> print(phys['targetname','H','G'])    # doctest: +REMOTE_DATA +NORMALIZE_WHITESPACE
+    >>> print(phys['targetname','H','G'])    # doctest: +REMOTE_DATA
     <QTable length=1>
         targetname       H       G
                         mag
@@ -158,7 +158,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
     1 Ceres (A801 AA)    3.54    0.12
     >>> m = HG.from_phys(phys)                  # doctest: +REMOTE_DATA
     INFO: Model initialized for 1 Ceres (A801 AA). [sbpy.photometry.core]
-    >>> print(m)                             # doctest: +REMOTE_DATA +NORMALIZE_WHITESPACE
+    >>> print(m)                             # doctest: +REMOTE_DATA
     Model: HG
     Inputs: ('x',)
     Outputs: ('y',)
@@ -176,7 +176,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
     >>> # Initialize from orbital elements pulled from JPL Horizons that also
     >>> # contain the H and G parameters
     >>> elem = Orbit.from_horizons('Ceres')  # doctest: +REMOTE_DATA
-    >>> print(elem['targetname','H','G'])    # doctest: +REMOTE_DATA +NORMALIZE_WHITESPACE
+    >>> print(elem['targetname','H','G'])    # doctest: +REMOTE_DATA
     <QTable length=1>
         targetname       H       G
                         mag

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -149,16 +149,16 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
     >>>
     >>> # Initialize from physical parameters pulled from JPL SBDB
     >>> phys = Phys.from_sbdb('Ceres')       # doctest: +REMOTE_DATA
-    >>> print(phys['targetname','H','G'])    # doctest: +REMOTE_DATA
+    >>> print(phys['targetname','H','G'])    # doctest: +REMOTE_DATA +NORMALIZE_WHITESPACE
     <QTable length=1>
         targetname       H       G
                         mag
           str17       float64 float64
     ----------------- ------- -------
-    1 Ceres (A801 AA)    3.53    0.12
+    1 Ceres (A801 AA)    3.54    0.12
     >>> m = HG.from_phys(phys)                  # doctest: +REMOTE_DATA
     INFO: Model initialized for 1 Ceres (A801 AA). [sbpy.photometry.core]
-    >>> print(m)                             # doctest: +REMOTE_DATA
+    >>> print(m)                             # doctest: +REMOTE_DATA +NORMALIZE_WHITESPACE
     Model: HG
     Inputs: ('x',)
     Outputs: ('y',)
@@ -167,7 +167,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
          H     G
         mag
         ---- ----
-        3.53 0.12
+        3.54 0.12
     >>> print(m.meta['targetname'])          # doctest: +REMOTE_DATA
     1 Ceres (A801 AA)
     >>> print(m.radius)                      # doctest: +REMOTE_DATA
@@ -176,13 +176,13 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
     >>> # Initialize from orbital elements pulled from JPL Horizons that also
     >>> # contain the H and G parameters
     >>> elem = Orbit.from_horizons('Ceres')  # doctest: +REMOTE_DATA
-    >>> print(elem['targetname','H','G'])    # doctest: +REMOTE_DATA
+    >>> print(elem['targetname','H','G'])    # doctest: +REMOTE_DATA +NORMALIZE_WHITESPACE
     <QTable length=1>
         targetname       H       G
                         mag
           str17       float64 float64
     ----------------- ------- -------
-    1 Ceres (A801 AA)    3.53    0.12
+    1 Ceres (A801 AA)    3.54    0.12
     >>> m = HG.from_phys(elem)                    # doctest: +REMOTE_DATA
     INFO: Model initialized for 1 Ceres (A801 AA). [sbpy.photometry.core]
     >>>
@@ -284,7 +284,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
                             mag
               str17       float64 float64
         ----------------- ------- -------
-        1 Ceres (A801 AA)    3.53    0.12
+        1 Ceres (A801 AA)    3.54    0.12
         >>> m = HG.from_phys(phys)              # doctest: +REMOTE_DATA
         INFO: Model initialized for 1 Ceres (A801 AA). [sbpy.photometry.core]
         >>> print(m)                            # doctest: +REMOTE_DATA
@@ -296,7 +296,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
              H     G
             mag
             ---- ----
-            3.53 0.12
+            3.54 0.12
         >>> print(m.meta['targetname'])         # doctest: +REMOTE_DATA
         1 Ceres (A801 AA)
         >>> print(m.radius)                     # doctest: +REMOTE_DATA
@@ -365,7 +365,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
                              km     mag
               str17       float64 float64 float64
         ----------------- ------- ------- -------
-        1 Ceres (A801 AA)   469.7    3.53   0.12
+        1 Ceres (A801 AA)   469.7    3.54    0.12
         >>> m = HG.from_phys(phys)   # doctest: +REMOTE_DATA
         INFO: Model initialized for 1 Ceres (A801 AA). [sbpy.photometry.core]
         >>> m.wfb = 'V'              # doctest: +REMOTE_DATA
@@ -377,7 +377,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
             targetname    diameter  H    G            pv                  A
                              km    mag
         ----------------- -------- ---- ---- ------------------- --------------------
-        1 Ceres (A801 AA)    939.4 3.53 0.12 0.07695019128044604 0.028036846480119768
+        1 Ceres (A801 AA)    939.4 3.54 0.12 0.07624470768627523 0.027779803126557152
         """  # noqa: E501
         cols = {}
         if (self.meta is not None) and ('targetname' in self.meta.keys()):


### PR DESCRIPTION
Get remote tests working by:
* updating some remote data that have changed (Ceres photometric model, again)
* update LTE.from_Drahus test to match astropy v5 behavior, and skip the test when astropy < 5
* instantiate astroquery's MPC class before using it ( astropy/astroquery#2280 )