### PR TITLE
Parse comet types A and I (Issue #332)

### DIFF
--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -310,8 +310,8 @@ class Names():
         import re
 
         # define comet matching pattern
-        pat = ('^(([1-9][0-9]*[PDCX]'
-               '(-[A-Z]{1,2})?)|[PDCX]/)'  # type/number/fragm [0,1,2]
+        pat = ('^(([1-9][0-9]*[PDCXAI]'
+               '(-[A-Z]{1,2})?)|[PDCXAI]/)'  # type/number/fragm [0,1,2]
                '|([-]?[0-9]{3,4}[ _][A-Z]{1,2}[0-9]{0,3}(-[1-9A-Z]{0,2})?)'
                # designation [3,4]
                '|((([dvA-Z][a-z\']? ?[A-Za-z\-]*)[ -]?[A-Z]?[1-9]*[a-z]*)'

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -33,7 +33,9 @@ comets = {
     'C/2014 S2 (Pan-STARRS)': {'type': 'C', 'desig': '2014 S2',
                                'name': 'Pan-STARRS'},
     'C/2014 S2 (PanSTARRS)': {'type': 'C', 'desig': '2014 S2',
-                              'name': 'PanSTARRS'}
+                              'name': 'PanSTARRS'},
+    'A/2018 V3': {'type': 'A', 'desig': '2018 V3'},
+    '2I/Borisov': {'type': 'I', 'number': 2, 'name': 'Borisov'}
 }
 
 # name: expected result from parse_asteroid()


### PR DESCRIPTION
Small change to allow `Names.parse_comet` to parse comets of type A and I. Note that `sbpy/data/tests/test_names.py` now fails for object "1A" at `test_asteroid_or_comet'.