### PR TITLE
Revert H unit assignment 2022.07

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,25 @@ sbpy.data
 
 - Added ``Orbit.tisserand`` to calculate the Tisserand parameter of small
   body's orbits with respect to planets. [#325]
+
 - Added ``Orbit.D_criterion`` to evaluate the D-criterion between two sets
   of orbital elements. [#325]
 - Added ``DataClass.__contains__`` to enable `in` operator for ``DataClass``
   objects. [#357]
+
+
+Bug Fixes
+---------
+
+sbpy.data
+^^^^^^^^^
+
+- Cometary magnitudes obtained via ``Phys.from_sbdb`` (i.e., M1 and M2) now have
+  appropriate units. [#349]
+
+- Asteroids with A/ designations (e.g., A/2019 G2) are correctly identified by
+  ``Names`` as asteroids.  Improved handling of interstellar object (I/)
+  designations: they do not parse as cometary or asteroidal. [#334, #340]
 
 
 0.3.0 (2022-04-28)

--- a/sbpy/data/phys.py
+++ b/sbpy/data/phys.py
@@ -109,12 +109,8 @@ class Phys(DataClass):
                 elif isinstance(val, u.CompositeUnit):
                     for unit in val.bases:
                         columnunits[key].add(unit)
-                elif key == 'H':
-                    # fix for astroquery <0.4.2
-                    columnunits[key].add(u.mag)
-                elif key in ['M1', 'M2', 'M1_sig', 'M2_sig']:
-                    columnunits[key].add(u.mag)
-                elif key in ['M1', 'M2', 'M1_sig', 'M2_sig']:
+                elif key in ['H', 'M1', 'M2', 'M1_sig', 'M2_sig']:
+                    # fix for lack of units from SBDB via astroquery
                     columnunits[key].add(u.mag)
 
             alldata.append(data)

--- a/sbpy/data/phys.py
+++ b/sbpy/data/phys.py
@@ -109,6 +109,9 @@ class Phys(DataClass):
                 elif isinstance(val, u.CompositeUnit):
                     for unit in val.bases:
                         columnunits[key].add(unit)
+                elif key == 'H':
+                    # fix for astroquery <0.4.2
+                    columnunits[key].add(u.mag)
                 elif key in ['M1', 'M2', 'M1_sig', 'M2_sig']:
                     columnunits[key].add(u.mag)
                 elif key in ['M1', 'M2', 'M1_sig', 'M2_sig']:

--- a/sbpy/data/tests/test_phys_remote.py
+++ b/sbpy/data/tests/test_phys_remote.py
@@ -23,10 +23,13 @@ def test_from_sbdb_comet():
     """Regression test for issue #349.
 
     As of June 2022, astroquery does not assign units to M1, M2 and their
-    uncertainties.
+    uncertainties, nor H.
 
     """
-    # need a comet with all both M1 and M2, and their uncertainties:
+    # need a comet with both M1 and M2, and their uncertainties:
     data = Phys.from_sbdb('147P')
     for k in ('M1', 'M2', 'M1_sig', 'M2_sig'):
         assert isinstance(data[k], u.Quantity) and data[k].unit == u.mag
+
+    data = Phys.from_sbdb('1')
+    assert isinstance(data['H'], u.Quantity) and data['H'].unit == u.mag

--- a/sbpy/data/tests/test_phys_remote.py
+++ b/sbpy/data/tests/test_phys_remote.py
@@ -20,7 +20,7 @@ def test_from_sbdb():
 
 @pytest.mark.remote_data
 def test_from_sbdb_comet():
-    """Regression test for issue #349.
+    """Regression test for issues #349 and #358.
 
     As of June 2022, astroquery does not assign units to M1, M2 and their
     uncertainties, nor H.


### PR DESCRIPTION
Absolute magnitudes from SBDB via astroquery do not have units of magnitude.  Add them.  This restores the behavior we had before #349.