### PR TITLE
Fix `DataClass.__setitem__`

### DIFF
--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -653,7 +653,7 @@ class DataClass():
         self.table.__setitem__(ident, val)
 
     def __contains__(self, value):
-        """Use cls._translate_columns to realize the `in` operator"""
+        """To support `in` operator that allows for alternative names"""
         if (value in self.table.colnames) or \
             (value in sum([Conf.fieldnames[Conf.fieldname_idx.get(x, slice(0))]
                            for x in self.table.colnames], [])):
@@ -679,14 +679,12 @@ class DataClass():
                 continue
             # colname is an alternative column name
             else:
-                found = False
                 for alt in Conf.fieldnames[
                             Conf.fieldname_idx.get(colname, slice(0))]:
                     if alt in self.field_names:
                         translated_colnames[idx] = alt
-                        found = True
                         break
-                if not found:
+                else:
                     raise KeyError('field "{:s}" not available.'.format(
                         colname))
 

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -657,12 +657,12 @@ class DataClass():
 
     def __contains__(self, value):
         """Use cls._translate_columns to realize the `in` operator"""
-        try:
-            _ = self._translate_columns(value)
-        except KeyError:
-            return False
-        else:
+        if (value in self.table.colnames) or \
+            (value in sum([Conf.fieldnames[Conf.fieldname_idx.get(x, slice(0))]
+                            for x in self.table.colnames], [])):
             return True
+        else:
+            return False
 
     def _translate_columns(self, target_colnames):
         """Translate target_colnames to the corresponding column names

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -656,7 +656,7 @@ class DataClass():
         """Use cls._translate_columns to realize the `in` operator"""
         if (value in self.table.colnames) or \
             (value in sum([Conf.fieldnames[Conf.fieldname_idx.get(x, slice(0))]
-                            for x in self.table.colnames], [])):
+                           for x in self.table.colnames], [])):
             return True
         else:
             return False

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -681,22 +681,17 @@ class DataClass():
             if colname in self.field_names:
                 continue
             # colname is an alternative column name
-            elif colname in sum(Conf.fieldnames, []):
+            else:
                 found = False
-                for alt in Conf.fieldnames[Conf.fieldname_idx[colname]]:
-                    # translation available for colname
+                for alt in Conf.fieldnames[
+                            Conf.fieldname_idx.get(colname, slice(0))]:
                     if alt in self.field_names:
                         translated_colnames[idx] = alt
                         found = True
                         break
-                # not found in the table
                 if not found:
-                    raise KeyError('field {:s} not available.'.format(
+                    raise KeyError('field "{:s}" not available.'.format(
                         colname))
-            # colname is unknown, raise a KeyError
-            else:
-                raise KeyError('field {:s} not available.'.format(
-                    colname))
 
         return translated_colnames
 

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -648,11 +648,8 @@ class DataClass():
         # `astropy.table.Table.__setitem__` only allows to set a single
         # column.  Only this case is checked here for alternative column
         # name.  All other cases are directly passed to `table.__setitem__`.
-        if isinstance(ident, str):
-            try:
-                ident = self._translate_columns(ident)[0]
-            except KeyError:
-                pass
+        if isinstance(ident, str) and ident in self:
+            ident = self._translate_columns(ident)[0]
         self.table.__setitem__(ident, val)
 
     def __contains__(self, value):

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -643,9 +643,17 @@ class DataClass():
         # return as new instance of this class for all other identifiers
         return self.from_table(self.table[ident])
 
-    def __setitem__(self, *args):
+    def __setitem__(self, ident, val):
         """Refer cls.__setitem__ to self._table"""
-        self.table.__setitem__(*args)
+        # `astropy.table.Table.__setitem__` only allows to set a single
+        # column.  Only this case is checked here for alternative column
+        # name.  All other cases are directly passed to `table.__setitem__`.
+        if isinstance(ident, str):
+            try:
+                ident = self._translate_columns(ident)[0]
+            except KeyError:
+                pass
+        self.table.__setitem__(ident, val)
 
     def __contains__(self, value):
         """Use cls._translate_columns to realize the `in` operator"""

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -313,6 +313,14 @@ def test_get_set():
     assert data['z'][1] == 2
     assert isinstance(data, DataClass)
 
+    # modify existing column using alternative name
+    data = DataClass.from_dict(
+        {'rh': [1, 2, 3] * u.au,
+         'delta': [4, 5, 6] * u.au})
+    data['r'] = [7, 8, 9] * u.au
+    assert u.allclose(data['rh'], [7, 8, 9] * u.au)
+    assert set(data.field_names) == {'rh', 'delta'}
+
 
 def test_units():
     """ test units on multi-row tables """


### PR DESCRIPTION
This fix allows `DataClass.__setitem__` to set an existing column with an alternative name, rather than adding a new column.
