### PR TITLE
Enable combining `DataClass` objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ sbpy.data
 - Added ``DataClass.__contains__`` to enable `in` operator for ``DataClass``
   objects. [#357]
 
-- Added ``DataClass.add_row``, ``DataClass.add_column``, ``DataClass.join``
+- Added ``DataClass.add_row``, ``DataClass.vstack``
   methods. [#367]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ sbpy.data
   objects. [#357]
 
 - Added ``DataClass.add_row``, ``DataClass.add_column``, ``DataClass.join``
-  methods. [#xxx]
+  methods. [#367]
 
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ sbpy.data
 - Added ``DataClass.__contains__`` to enable `in` operator for ``DataClass``
   objects. [#357]
 
+- Added ``DataClass.add_row``, ``DataClass.add_column``, ``DataClass.join``
+  methods. [#xxx]
+
 
 Bug Fixes
 ---------

--- a/docs/sbpy/data/dataclass.rst
+++ b/docs/sbpy/data/dataclass.rst
@@ -314,8 +314,8 @@ object, you can use `~sbpy.data.DataClass.field_names`:
     ['ra', 'dec', 't']
 
 You can also use the `in` operator to check if a field is contained in
-a `~sbpy.data.DataClass` object.  Alternative field names can also be
-used for the `in` test:
+a `~sbpy.data.DataClass` object.  Alternative field names can be used
+for the `in` test:
 
     >>> 'ra' in obs
     True
@@ -412,7 +412,7 @@ directly addressing them:
     <Quantity [10.323423, 10.333453, 10.343452] deg>
 
 The basic functionalities to modify the data table are implemented in
-`~sbpy.data.DataClass`, including adding rows and columns and join a
+`~sbpy.data.DataClass`, including adding rows and columns and stack a
 DataClass with another DataClass object or an `~astropy.table.Table`
 object.
 
@@ -438,7 +438,7 @@ or if you want to add a column to your object:
 
 .. doctest-requires:: astropy>=5
 
-    >>> obs.add_column(['V', 'V', 'R', 'i'], name='filter')
+    >>> obs.apply(['V', 'V', 'R', 'i'], name='filter')
     >>> obs
     <QTable length=4>
         ra       dec          t       filter
@@ -472,7 +472,7 @@ Similarly, existing columns can be modified using:
 
     >>> obs['filter'] = ['g', 'i', 'R', 'V']
 
-If you want to join two observations into a single object:
+If you want to stack two observations into a single object:
 
 .. doctest-requires:: astropy>=5
 
@@ -483,7 +483,7 @@ If you want to join two observations into a single object:
     >>> obs2 = Obs.from_columns([ra, dec, epoch, phase],
     ...     names=['ra', 'dec', 't', 'phase'])
     >>>
-    >>> obs.join(obs2)
+    >>> obs.stack(obs2)
     >>> obs
     <QTable length=7>
         ra       dec          t       filter filter2  phase
@@ -498,9 +498,10 @@ If you want to join two observations into a single object:
     20.233453  12.41562  2451623.7345     --      --    12.3
     20.243452  12.40435  2451623.8525     --      --    15.6
 
-Note that the data table to be joined doesn't have to have the same
-columns as the original data table.  The empty field will be automatically
-masked out.
+Note that the data table to be stacked doesn't have to have the same
+columns as the original data table.  A keyword `join_type` is used to
+decide how to process the different sets of columns.  See
+`~astropy.table.Table.vstack()` for more detail.
 
 Because the underlying `~astropy.table.QTable` can be exposed by the
 `~sbpy.data.DataClass.table` property, it is possible to modify the data

--- a/docs/sbpy/data/dataclass.rst
+++ b/docs/sbpy/data/dataclass.rst
@@ -483,7 +483,7 @@ If you want to stack two observations into a single object:
     >>> obs2 = Obs.from_columns([ra, dec, epoch, phase],
     ...     names=['ra', 'dec', 't', 'phase'])
     >>>
-    >>> obs.stack(obs2)
+    >>> obs.vstack(obs2)
     >>> obs
     <QTable length=7>
         ra       dec          t       filter filter2  phase

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -1005,15 +1005,15 @@ class DataClass():
                                    format='isot' if isinstance(vals[i], str)
                                    else 'jd')
             vals = DataClass.from_rows(vals, names, units=units)
-        self.join(vals)
+        self.vstack(vals)
 
-    def join(self, data):
-        """Join another DataClass object to the end of DataClass
+    def vstack(self, data, **kwargs):
+        """Stack another DataClass object to the end of DataClass
 
-        The DataClass object doesn't need to have the same set of columns
-        as the existing object.  The original dataclass will be expanded
-        with new columns, and the cells with no values will be masked in
-        both the existing dataclass and the newly joined rows.
+        Similar to `~astropy.table.Table.vstack`, the DataClass object
+        to be stacked doesn't have to have the same set of columns as
+        the existing object.  The `join_type` keyword parameter will be
+        used to decide how to process the different sets of columns.
 
         Joining will be in-place.
 
@@ -1021,6 +1021,8 @@ class DataClass():
         ----------
         data : `~sbpy.data.DataClass`, dict, `~astropy.table.Table`
             Object to be joined with the current object
+        kwargs : dict
+            Keyword parameters accepted by `~astropy.table.Table.vstack`.
 
         Examples
         --------
@@ -1031,7 +1033,7 @@ class DataClass():
         ...         {'rh': [1, 2, 3] * u.au, 'delta': [1, 2, 3] * u.au})
         >>> data2 = DataClass.from_dict(
         ...         {'rh': [4, 5] * u.au, 'phase': [15, 15] * u.deg})
-        >>> data1.join(data2)
+        >>> data1.vstack(data2)
         """
         # check and process input data
         if isinstance(data, dict):
@@ -1048,4 +1050,4 @@ class DataClass():
         data.table.rename_columns(data.field_names, alt)
 
         # join with the input table
-        self.table = vstack([self.table, data.table], join_type='outer')
+        self.table = vstack([self.table, data.table], **kwargs)

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -670,7 +670,7 @@ class DataClass():
         raises a `KeyError` if a match cannot be found for an input column
         name (neither in this object nor defined in `Conf.fieldnames`).
         If `ignore_missing == True`, then the problemtic column name will
-        be silently carried ouver and returned.
+        be silently carried over and returned.
         """
 
         if not isinstance(target_colnames, (list, ndarray, tuple)):
@@ -1006,27 +1006,6 @@ class DataClass():
                                    else 'jd')
             vals = DataClass.from_rows(vals, names, units=units)
         self.join(vals)
-
-    def add_column(self, col, name=None, unit=None):
-        """Add a new column
-
-        col : `~astropy.table.Column` object, or sequence
-            The column to be added.  Must have the same length as the
-            existing table.
-        name : array-like str, optional
-            Specify the name of added column.  If not ``None``, then
-            takes precedence over ``col.name``.
-        unit : array-like `~astropy.units` objects or str, optional
-            Unit to be applied to the new column.  If not ``None``, then
-            take precedence over ``col.unit``.
-        """
-        if name is None:
-            name = getattr(col, 'name', '')
-        if unit is None:
-            unit = getattr(col, 'unit', None)
-        if name in self:
-            raise DataClassError('Column {} already exists.'.format(name))
-        self.apply(col, name=name, unit=unit)
 
     def join(self, data):
         """Join another DataClass object to the end of DataClass

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -934,3 +934,59 @@ class DataClass():
                 ):
                     raise FieldError('Field {} does not have units of {}'
                                      .format(test_field, str(dim.unit)))
+
+    def add_row(self, vals, names=None):
+        """Add a new row to the end of DataClass.
+
+        This is similar to `astropy.table.Table.add_row`, but allows for
+        a set of different columns in the new row from the original DataClass
+        object.  It also allows for aliases of column names.
+
+        Parameters
+        ----------
+        vals : tuple, list, dict or None
+            Use the specified values in the new row
+        mask : tuple, list, dict or None
+            Use the specified mask values in the new row
+        names : iterable of strings
+            The names of columns if not implicitly specified in `vals`.
+            Ignored if the column names are specified in `vals`.
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> from sbpy.data import DataClass
+        >>>
+        >>> data = DataClass.from_dict(
+        ...         {'rh': [1, 2, 3] * u.au, 'delta': [1, 2, 3] * u.au})
+        >>> row = {'rh': 4 * u.au, 'delta': 4 * u.au, 'phase': 15 * u.deg}
+        >>> data.add_row(row)
+        """
+        pass
+
+    def join(self, data):
+        """Join another DataClass object to the end of DataClass
+
+        The DataClass object doesn't need to have the same set of columns
+        as the existing object.  The original dataclass will be expanded
+        with new columns, and the cells with no values will be masked in
+        both the existing dataclass and the newly joined rows.
+
+        Parameters
+        ----------
+        data : `sbpy.data.DataClass`
+            Object to be joined with the current object
+
+        Examples
+        --------
+        >>> import astropy.units as u
+        >>> from sbpy.data import DataClass
+        >>>
+        >>> data1 = DataClass.from_dict(
+        ...         {'rh': [1, 2, 3] * u.au, 'delta': [1, 2, 3] * u.au})
+        >>> data2 = DataClass.from_dict(
+                    {'rh': [4, 5] * u.au, 'phase': 15 * u.deg}
+        >>> data1.join(data2)
+        """
+        pass
+

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -1002,7 +1002,8 @@ class DataClass():
             for i, k in enumerate(names):
                 if k in self and isinstance(self[k], Time):
                     vals[i] = Time(vals[i], scale=self[k].scale,
-                        format='isot' if isinstance(vals[i], str) else 'jd')
+                                   format='isot' if isinstance(vals[i], str)
+                                   else 'jd')
             vals = DataClass.from_rows(vals, names, units=units)
         self.join(vals)
 
@@ -1060,7 +1061,8 @@ class DataClass():
             data = DataClass.from_table(data)
         if not isinstance(data, DataClass):
             raise ValueError('DataClass, dict, or astorpy.table.Table are '
-                'expected, but {} is received.'.format(type(data)))
+                             'expected, but {} is received.'.
+                             format(type(data)))
 
         # adjust input column names for alises
         alt = self._translate_columns(data.field_names, ignore_missing=True)

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -661,12 +661,15 @@ class DataClass():
         else:
             return False
 
-    def _translate_columns(self, target_colnames):
+    def _translate_columns(self, target_colnames, ignore_missing=False):
         """Translate target_colnames to the corresponding column names
         present in this object's table. Returns a list of actual column
         names present in this object that corresponds to target_colnames
-        (order is preserved). Raises KeyError if not all columns are
-        present or one or more columns could not be translated.
+        (order is preserved). If `ignore_missing == False` (default),
+        raises a `KeyError` if a match cannot be found for an input column
+        name (neither in this object nor defined in `Conf.fieldnames`).
+        If `ignore_missing == True`, then the problemtic column name will
+        be silently carried ouver and returned.
         """
 
         if not isinstance(target_colnames, (list, ndarray, tuple)):
@@ -674,19 +677,19 @@ class DataClass():
 
         translated_colnames = deepcopy(target_colnames)
         for idx, colname in enumerate(target_colnames):
-            # colname is already a column name in self.table
-            if colname in self.field_names:
-                continue
-            # colname is an alternative column name
-            else:
+            if colname not in self.field_names:
+                # colname not already in self.table
                 for alt in Conf.fieldnames[
                             Conf.fieldname_idx.get(colname, slice(0))]:
+                    # defined in `Conf.fieldnames`
                     if alt in self.field_names:
                         translated_colnames[idx] = alt
                         break
                 else:
-                    raise KeyError('field "{:s}" not available.'.format(
-                        colname))
+                    # undefined colname
+                    if not ignore_missing:
+                        raise KeyError('field "{:s}" not available.'.format(
+                            colname))
 
         return translated_colnames
 

--- a/sbpy/data/core.py
+++ b/sbpy/data/core.py
@@ -1006,6 +1006,27 @@ class DataClass():
             vals = DataClass.from_rows(vals, names, units=units)
         self.join(vals)
 
+    def add_column(self, col, name=None, unit=None):
+        """Add a new column
+
+        col : `~astropy.table.Column` object, or sequence
+            The column to be added.  Must have the same length as the
+            existing table.
+        name : array-like str, optional
+            Specify the name of added column.  If not ``None``, then
+            takes precedence over ``col.name``.
+        unit : array-like `~astropy.units` objects or str, optional
+            Unit to be applied to the new column.  If not ``None``, then
+            take precedence over ``col.unit``.
+        """
+        if name is None:
+            name = getattr(col, 'name', '')
+        if unit is None:
+            unit = getattr(col, 'unit', None)
+        if name in self:
+            raise DataClassError('Column {} already exists.'.format(name))
+        self.apply(col, name=name, unit=unit)
+
     def join(self, data):
         """Join another DataClass object to the end of DataClass
 

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -663,6 +663,28 @@ def test_add_row():
     assert u.isclose(tab[-1]['phase'], r['DEC'])
 
 
+def test_add_column():
+    """test DataClass.add_column"""
+    tab = DataClass.from_columns([[2451223, 2451224, 2451226]*u.d,
+                                  [120.1, 121.3, 124.9]*u.deg,
+                                  [12.4, 12.2, 10.8]*u.deg],
+                                 names=('JD', 'RA', 'DEC'))
+    filt = ['V', 'V', 'R']
+    # add astropy Column
+    tab.add_column(Column(filt, name='filter'))
+    assert set(tab.field_names) == {'JD', 'RA', 'DEC', 'filter'}
+    assert all(tab['filter'] == filt)
+
+    # add a sequence
+    tab.add_column(filt, name='filter1')
+    assert set(tab.field_names) == {'JD', 'RA', 'DEC', 'filter', 'filter1'}
+    assert all(tab['filter1'] == filt)
+
+    # duplicated column
+    with pytest.raises(DataClassError):
+        tab.add_column(filt, name='filter')
+
+
 def test_join():
     """test DataClass.join"""
     tab = DataClass.from_columns([[2451223, 2451224, 2451226]*u.d,

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -639,7 +639,7 @@ def test_add_row():
 
     # add an iterable with specified column names
     r = [2451132 * u.d, 140 * u.deg, 3 * u.au]
-    n = ['JD', 'RA', 'rh'] # adding a new column and missing an existing column
+    n = ['JD', 'RA', 'rh']  # with a new column and missing an existing column
     tab.add_row(r, n)
     assert len(tab) == 7
     assert set(tab.field_names) == {'JD', 'RA', 'DEC', 'rh'}

--- a/sbpy/data/tests/test_dataclass.py
+++ b/sbpy/data/tests/test_dataclass.py
@@ -452,6 +452,9 @@ def test_translate_columns_and_contains(monkeypatch):
         tab._translate_columns(['x'])  # undefined column name
         tab._translate_columns(['dd'])  # defined column name but not in table
 
+    trans = tab._translate_columns(['x', 'dd'], ignore_missing=True)
+    assert trans == ['x', 'dd']
+
     assert 'aa' in tab
     assert 'bb' in tab
     assert 'zz' in tab


### PR DESCRIPTION
This PR responds to issue #203 to provide a mechanism to combine `DataClass` objects.  New methods implemented include:

- `.add_row()`
- `.add_column()`
- `.join()`

These methods allow for the same flexibilities provided by other `DataClass` methods, such as column name alias, expanding table with a new `DataClass` or `astropy.table.Table` object, new row, or new column with different shapes from the original table.

The implementation tries to make use of the existing functionalities from `astropy.table.Table` and `DataClass` as much as possible.  `join` function uses `astropy.table.vstack`.  `add_row` uses `DataClass.from_rows` and `join`.  `add_column` uses `DataClass.apply`.