### PR TITLE
Fix indentation on documentation directives.

### DIFF
--- a/docs/development/design-principles.rst
+++ b/docs/development/design-principles.rst
@@ -19,7 +19,7 @@ Epochs must be Time objects
 ---------------------------
 
 * Any kind of epoch or point in time must be of type `~astropy.time.Time`; time scales must be properly set and propagated through all functions.
-  
+
 
 Use sbpy ``DataClass`` objects
 ------------------------------
@@ -30,49 +30,49 @@ Use sbpy ``DataClass`` objects
 
 * The classes enable easy parameter passing from online sources.  Compare the following:
 
-.. code-block:: python
-     
-    eph = Ephem.from_horizons('2P')
-    # rh, delta required, phase angle is optional:
-    Afrho(wave, fluxd, aper, eph['rh'], eph['delta'], phase=eph['phase'])
-    # more to the point:
-    Afrho(wave, fluxd, aper, eph)
+    .. code-block:: python
 
-  Carefully document which fields are used by your function or method.
+        eph = Ephem.from_horizons('2P')
+        # rh, delta required, phase angle is optional:
+        Afrho(wave, fluxd, aper, eph['rh'], eph['delta'], phase=eph['phase'])
+        # more to the point:
+        Afrho(wave, fluxd, aper, eph)
+
+    Carefully document which fields are used by your function or method.
      
 * Dictionary-like objects may be allowed for user input, but should be internally converted to a ``DataClass`` object with the `~sbpy.data.dataclass_input` decorator:
 
-.. code-block:: python
-     
-    @dataclass_input(eph=Ephem)
-    def H11(eph):
-        ...
+    .. code-block:: python
 
-  The same, but using function annotations:
-  
-.. code-block:: python
-     
-    @dataclass_input
-    def H11(eph: Ephem):
-        ...
+        @dataclass_input(eph=Ephem)
+        def H11(eph):
+            ...
+
+    The same, but using function annotations:
+
+    .. code-block:: python
+
+        @dataclass_input
+        def H11(eph: Ephem):
+            ...
 
 * Exceptions are allowed when only one parameter is needed, e.g., ``phase_func(phase)``.  But instead consider using the relevant ``DataClass`` object, and decorating the function with `~sbpy.data.quantity_to_dataclass`:
 
-.. code-block:: python
+    .. code-block:: python
 
-    @quantity_to_dataclass(eph=(Ephem, 'phase'))
-    def phase_func(eph):
-        ...
+        @quantity_to_dataclass(eph=(Ephem, 'phase'))
+        def phase_func(eph):
+            ...
 
-  The decorator may be stacked with ``dataclass_input`` for maximum
-  flexibility:
+    The decorator may be stacked with ``dataclass_input`` for maximum
+    flexibility:
 
-.. code-block:: python
+    .. code-block:: python
 
-    @dataclass_input
-    @quantity_to_dataclass(eph=(Ephem, 'phase'))
-    def phase_func(eph):
-        ...
+        @dataclass_input
+        @quantity_to_dataclass(eph=(Ephem, 'phase'))
+        def phase_func(eph):
+            ...
 
 
 Append fields to ``DataClass`` at the user's request
@@ -94,11 +94,11 @@ Cite relevant works
 
 * Citations may be executed internally with :func:`sbpy.bib.register`, or via the `~sbpy.bib.cite` decorator:
 
-.. code-block:: python
+    .. code-block:: python
 
-    @cite({'method': '1687pnpm.book.....N'})
-    def force(mass, acceleration):
-        return mass * acceleration
+        @cite({'method': '1687pnpm.book.....N'})
+        def force(mass, acceleration):
+            return mass * acceleration
 
 * Labels describing references (``'method'`` in the above example) are
   required to start with the following strings: ``'method'`` (for

--- a/docs/development/design-principles.rst
+++ b/docs/development/design-principles.rst
@@ -30,49 +30,49 @@ Use sbpy ``DataClass`` objects
 
 * The classes enable easy parameter passing from online sources.  Compare the following:
 
-  .. code-block:: python
+.. code-block:: python
      
-     eph = Ephem.from_horizons('2P')
-     # rh, delta required, phase angle is optional:
-     Afrho(wave, fluxd, aper, eph['rh'], eph['delta'], phase=eph['phase'])
-     # more to the point:
-     Afrho(wave, fluxd, aper, eph)
+    eph = Ephem.from_horizons('2P')
+    # rh, delta required, phase angle is optional:
+    Afrho(wave, fluxd, aper, eph['rh'], eph['delta'], phase=eph['phase'])
+    # more to the point:
+    Afrho(wave, fluxd, aper, eph)
 
   Carefully document which fields are used by your function or method.
      
 * Dictionary-like objects may be allowed for user input, but should be internally converted to a ``DataClass`` object with the `~sbpy.data.dataclass_input` decorator:
 
-  .. code-block:: python
+.. code-block:: python
      
-     @dataclass_input(eph=Ephem)
-     def H11(eph):
-         ...
+    @dataclass_input(eph=Ephem)
+    def H11(eph):
+        ...
 
   The same, but using function annotations:
   
-  .. code-block:: python
+.. code-block:: python
      
-     @dataclass_input
-     def H11(eph: Ephem):
-         ...
+    @dataclass_input
+    def H11(eph: Ephem):
+        ...
 
 * Exceptions are allowed when only one parameter is needed, e.g., ``phase_func(phase)``.  But instead consider using the relevant ``DataClass`` object, and decorating the function with `~sbpy.data.quantity_to_dataclass`:
 
-  .. code-block:: python
+.. code-block:: python
 
-     @quantity_to_dataclass(eph=(Ephem, 'phase'))
-     def phase_func(eph):
-         ...
+    @quantity_to_dataclass(eph=(Ephem, 'phase'))
+    def phase_func(eph):
+        ...
 
   The decorator may be stacked with ``dataclass_input`` for maximum
   flexibility:
 
-  .. code-block:: python
+.. code-block:: python
 
-     @dataclass_input
-     @quantity_to_dataclass(eph=(Ephem, 'phase'))
-     def phase_func(eph):
-         ...
+    @dataclass_input
+    @quantity_to_dataclass(eph=(Ephem, 'phase'))
+    def phase_func(eph):
+        ...
 
 
 Append fields to ``DataClass`` at the user's request
@@ -94,11 +94,11 @@ Cite relevant works
 
 * Citations may be executed internally with :func:`sbpy.bib.register`, or via the `~sbpy.bib.cite` decorator:
 
-  .. code-block:: python
+.. code-block:: python
 
-     @cite({'method': '1687pnpm.book.....N'})
-     def force(mass, acceleration):
-         return mass * acceleration
+    @cite({'method': '1687pnpm.book.....N'})
+    def force(mass, acceleration):
+        return mass * acceleration
 
 * Labels describing references (``'method'`` in the above example) are
   required to start with the following strings: ``'method'`` (for

--- a/docs/sbpy/activity/dust.rst
+++ b/docs/sbpy/activity/dust.rst
@@ -8,17 +8,17 @@ Dust comae (`sbpy.activity.dust`)
 
 The *Afρ* parameter of A'Hearn et al (1984) is based on observations of idealized cometary dust comae.  It is proportional to the observed flux density within a circular aperture.  The quantity is the product of dust albedo, dust filling factor, and the radius of the aperture at the distance of the comet.  It carries the units of *ρ* (length), and under certain assumptions is proportional to the dust production rate of the comet:
 
-  .. math::
+.. math::
 
-     Afρ = \frac{4 Δ^2 r_h^2}{ρ}\frac{F_c}{F_⊙}
+    Afρ = \frac{4 Δ^2 r_h^2}{ρ}\frac{F_c}{F_⊙}
 
 where *Δ* and *ρ* have the same (linear) units, but :math:`r_h` is in units of au.  :math:`F_c` * is the flux density of the comet in the aperture, and :math:`F_⊙` is that of the Sun at 1 au in the same units.  See A'Hearn et al. (1984) and Fink & Rubin (2012) for more details.
 
 The *εfρ* parameter is the thermal emission counterpart to *Afρ*, replacing albedo with IR emissivity, *ε*, and the solar spectrum with the Planck function, *B*:
 
-  .. math::
+.. math::
 
-     εfρ = \frac{F_c Δ^2}{π ρ B(T_c)}
+    εfρ = \frac{F_c Δ^2}{π ρ B(T_c)}
 
 where :math:`T_c` is the spectral temperature of the continuum (Kelley et al. 2013).
 

--- a/docs/sbpy/activity/dust.rst
+++ b/docs/sbpy/activity/dust.rst
@@ -10,7 +10,7 @@ The *Afρ* parameter of A'Hearn et al (1984) is based on observations of idealiz
 
 .. math::
 
-    Afρ = \frac{4 Δ^2 r_h^2}{ρ}\frac{F_c}{F_⊙}
+   Afρ = \frac{4 Δ^2 r_h^2}{ρ}\frac{F_c}{F_⊙}
 
 where *Δ* and *ρ* have the same (linear) units, but :math:`r_h` is in units of au.  :math:`F_c` * is the flux density of the comet in the aperture, and :math:`F_⊙` is that of the Sun at 1 au in the same units.  See A'Hearn et al. (1984) and Fink & Rubin (2012) for more details.
 
@@ -18,7 +18,7 @@ The *εfρ* parameter is the thermal emission counterpart to *Afρ*, replacing a
 
 .. math::
 
-    εfρ = \frac{F_c Δ^2}{π ρ B(T_c)}
+   εfρ = \frac{F_c Δ^2}{π ρ B(T_c)}
 
 where :math:`T_c` is the spectral temperature of the continuum (Kelley et al. 2013).
 
@@ -27,21 +27,21 @@ where :math:`T_c` is the spectral temperature of the continuum (Kelley et al. 20
 
 `Afrho` and `Efrho` are subclasses of `astropy`'s `~astropy.units.Quantity` and carry units of length.
 
-  >>> import numpy as np
-  >>> import astropy.units as u
-  >>> from sbpy.activity import Afrho, Efrho
-  >>>
-  >>> afrho = Afrho(100 * u.cm)
-  >>> print(afrho)    # doctest: +FLOAT_CMP
-  100.0 cm
-  >>> efrho = Efrho(afrho * 3.5)
-  >>> print(efrho)    # doctest: +FLOAT_CMP
-  350.0 cm
+   >>> import numpy as np
+   >>> import astropy.units as u
+   >>> from sbpy.activity import Afrho, Efrho
+   >>>
+   >>> afrho = Afrho(100 * u.cm)
+   >>> print(afrho)    # doctest: +FLOAT_CMP
+   100.0 cm
+   >>> efrho = Efrho(afrho * 3.5)
+   >>> print(efrho)    # doctest: +FLOAT_CMP
+   350.0 cm
 
 They may be converted to other units of length just like any `Quantity`:
 
-  >>> afrho.to('m')    # doctest: +FLOAT_CMP
-  <Afrho 1. m>
+   >>> afrho.to('m')    # doctest: +FLOAT_CMP
+   <Afrho 1. m>
 
 .. _afrho-to-from-flux-density:
 
@@ -58,30 +58,30 @@ The quantities may be initialized from flux densities.  Here, we reproduce one o
 
 The solar flux density at 1 au is also needed.  We use 1868 W/(m2 μm).
 
-  >>> from sbpy.data import Ephem
-  >>> from sbpy.calib import solar_fluxd
-  >>>
-  >>> solar_fluxd.set({
-  ...     'λ5240': 1868 * u.W / u.m**2 / u.um,
-  ...     'λ5240(lambda pivot)': 5240 * u.AA
-  ... })              # doctest: +IGNORE_OUTPUT
-  >>>
-  >>> flam = 10**-13.99 * u.Unit('erg/(s cm2 AA)')
-  >>> aper = 27200 * u.km
-  >>>
-  >>> eph = Ephem.from_dict({'rh': 4.785 * u.au, 'delta': 3.822 * u.au})
-  >>>
-  >>> afrho = Afrho.from_fluxd('λ5240', flam, aper, eph)
-  >>> print(afrho)    # doctest: +FLOAT_CMP
-  6029.90248952895 cm
+   >>> from sbpy.data import Ephem
+   >>> from sbpy.calib import solar_fluxd
+   >>>
+   >>> solar_fluxd.set({
+   ...     'λ5240': 1868 * u.W / u.m**2 / u.um,
+   ...     'λ5240(lambda pivot)': 5240 * u.AA
+   ... })              # doctest: +IGNORE_OUTPUT
+   >>>
+   >>> flam = 10**-13.99 * u.Unit('erg/(s cm2 AA)')
+   >>> aper = 27200 * u.km
+   >>>
+   >>> eph = Ephem.from_dict({'rh': 4.785 * u.au, 'delta': 3.822 * u.au})
+   >>>
+   >>> afrho = Afrho.from_fluxd('λ5240', flam, aper, eph)
+   >>> print(afrho)    # doctest: +FLOAT_CMP
+   6029.90248952895 cm
 
 Which is within a few percent of 6160 cm computed by A'Hearn et al.. The difference is likely due to the assumed solar flux density in the bandpass.
 
 The `Afrho` class may be converted to a flux density, and the original value is recovered.
 
-  >>> f = afrho.to_fluxd('λ5240', aper, eph).to('erg/(s cm2 AA)')
-  >>> print(np.log10(f.value))    # doctest: +FLOAT_CMP
-  -13.99
+   >>> f = afrho.to_fluxd('λ5240', aper, eph).to('erg/(s cm2 AA)')
+   >>> print(np.log10(f.value))    # doctest: +FLOAT_CMP
+   -13.99
 
 `Afrho` works seamlessly with `sbpy`'s spectral calibration framework (:ref:`sbpy-calib`) when the `astropy` affiliated package `synphot` is installed.  The solar flux density (via `~sbpy.calib.solar_fluxd`) is not required, but instead the spectral wavelengths or the system transmission of the instrument and filter:
 
@@ -108,15 +108,15 @@ Reproduce the *εfρ* of 246P/NEAT from Kelley et al. (2013).
 
 .. doctest-requires:: synphot
 
-  >>> wave = [15.8, 22.3] * u.um
-  >>> fluxd = [25.75, 59.2] * u.mJy
-  >>> aper = 11.1 * u.arcsec
-  >>> eph = Ephem.from_dict({'rh': 4.28 * u.au, 'delta': 3.71 * u.au})
-  >>> efrho = Efrho.from_fluxd(wave, fluxd, aper, eph)
-  >>> for i in range(len(wave)):
-  ...     print('{:5.1f} at {:.1f}'.format(efrho[i], wave[i]))    # doctest: +FLOAT_CMP
-  406.2 cm at 15.8 um
-  427.9 cm at 22.3 um
+   >>> wave = [15.8, 22.3] * u.um
+   >>> fluxd = [25.75, 59.2] * u.mJy
+   >>> aper = 11.1 * u.arcsec
+   >>> eph = Ephem.from_dict({'rh': 4.28 * u.au, 'delta': 3.71 * u.au})
+   >>> efrho = Efrho.from_fluxd(wave, fluxd, aper, eph)
+   >>> for i in range(len(wave)):
+   ...     print('{:5.1f} at {:.1f}'.format(efrho[i], wave[i]))    # doctest: +FLOAT_CMP
+   406.2 cm at 15.8 um
+   427.9 cm at 22.3 um
 
 Compare to 397.0 cm and 424.6 cm listed in Kelley et al. (2013).
 
@@ -130,16 +130,16 @@ Estimate the *Afρ* of comet C/2012 S1 (ISON) based on Pan-STARRS 1 photometry i
 
 .. doctest-requires:: synphot
 
-  >>> w = 0.617 * u.um
-  >>> m = 16.02 * u.ABmag
-  >>> aper = 5 * u.arcsec
-  >>> eph = {'rh': 5.234 * u.au, 'delta': 4.275 * u.au, 'phase': 2.6 * u.deg}
-  >>> afrho = Afrho.from_fluxd(w, m, aper, eph)
-  >>> print(afrho)    # doctest: +FLOAT_CMP
-  1948.496075629444 cm
-  >>> m2 = afrho.to_fluxd(w, aper, eph, unit=u.ABmag)    # doctest: +FLOAT_CMP
-  >>> print(m2)
-  16.02 mag(AB)
+   >>> w = 0.617 * u.um
+   >>> m = 16.02 * u.ABmag
+   >>> aper = 5 * u.arcsec
+   >>> eph = {'rh': 5.234 * u.au, 'delta': 4.275 * u.au, 'phase': 2.6 * u.deg}
+   >>> afrho = Afrho.from_fluxd(w, m, aper, eph)
+   >>> print(afrho)    # doctest: +FLOAT_CMP
+   1948.496075629444 cm
+   >>> m2 = afrho.to_fluxd(w, aper, eph, unit=u.ABmag)    # doctest: +FLOAT_CMP
+   >>> print(m2)
+   16.02 mag(AB)
 
 
 Phase angles and functions
@@ -147,29 +147,29 @@ Phase angles and functions
 
 Phase angle was not used in the previous section.  In the *Afρ* formalism, "albedo" includes the scattering phase function, and is more precisely written *A(θ)*, where *θ* is the phase angle.  The default behavior for `Afrho` is to compute *A(θ)fρ* as opposed to *A(0°)fρ*.  Returning to the A'Hearn et al. data, we scale *Afρ* to 0° from 3.3° phase using the :func:`~sbpy.activity.Afrho.to_phase` method:
 
-  >>> afrho = Afrho(6029.9 * u.cm)
-  >>> print(afrho.to_phase(0 * u.deg, 3.3 * u.deg))    # doctest: +FLOAT_CMP
-  6886.825981017757 cm
+   >>> afrho = Afrho(6029.9 * u.cm)
+   >>> print(afrho.to_phase(0 * u.deg, 3.3 * u.deg))    # doctest: +FLOAT_CMP
+   6886.825981017757 cm
 
 The default phase function is the Halley-Marcus composite phase function (:func:`~sbpy.activity.phase_HalleyMarcus`).  Any function or callable object that accepts an angle as a `~astropy.units.Quantity` and returns a scalar value may be used:
 
-  >>> Phi = lambda phase: 10**(-0.016 / u.deg * phase.to('deg'))
-  >>> print(afrho.to_phase(0 * u.deg, 3.3 * u.deg, Phi=Phi))    # doctest: +FLOAT_CMP
-  6809.419810008357 cm
+   >>> Phi = lambda phase: 10**(-0.016 / u.deg * phase.to('deg'))
+   >>> print(afrho.to_phase(0 * u.deg, 3.3 * u.deg, Phi=Phi))    # doctest: +FLOAT_CMP
+   6809.419810008357 cm
 
 To correct an observed flux density for the phase function, use the ``phasecor`` option of :func:`~sbpy.activity.Afrho.to_fluxd` and :func:`~sbpy.activity.Afrho.from_fluxd` methods:
 
-  >>> flam = 10**-13.99 * u.Unit('erg/(s cm2 AA)')
-  >>> aper = 27200 * u.km
-  >>> eph = Ephem.from_dict({
-  ...     'rh': 4.785 * u.au,
-  ...     'delta': 3.822 * u.au,
-  ...     'phase': 3.3 * u.deg
-  ... })
-  >>>
-  >>> afrho = Afrho.from_fluxd('λ5240', flam, aper, eph, phasecor=True)
-  >>> print(afrho)    # doctest: +FLOAT_CMP
-  6886.828824340642 cm
+   >>> flam = 10**-13.99 * u.Unit('erg/(s cm2 AA)')
+   >>> aper = 27200 * u.km
+   >>> eph = Ephem.from_dict({
+   ...     'rh': 4.785 * u.au,
+   ...     'delta': 3.822 * u.au,
+   ...     'phase': 3.3 * u.deg
+   ... })
+   >>>
+   >>> afrho = Afrho.from_fluxd('λ5240', flam, aper, eph, phasecor=True)
+   >>> print(afrho)    # doctest: +FLOAT_CMP
+   6886.828824340642 cm
 
 
 Apertures
@@ -177,20 +177,20 @@ Apertures
 
 Other apertures may be used, as long as they can be converted into an equivalent radius, assuming a coma with a *1/ρ* surface brightness distribution.  `~sbpy.activity` has a collection of useful geometries.
 
-  >>> from sbpy.activity import CircularAperture, AnnularAperture, RectangularAperture, GaussianAperture
-  >>> apertures = (
-  ...   ( '10" radius circle', CircularAperture(10 * u.arcsec)),
-  ...   (    '5"–10" annulus', AnnularAperture([5, 10] * u.arcsec)),
-  ...   (       '2"x10" slit', RectangularAperture([2, 10] * u.arcsec)),
-  ...   ('σ=5" Gaussian beam', GaussianAperture(5 * u.arcsec))
-  ... )
-  >>> for name, aper in apertures:
-  ...     afrho = Afrho.from_fluxd('λ5240', flam, aper, eph)
-  ...     print('{:18s} = {:5.0f}'.format(name, afrho))    # doctest: +FLOAT_CMP
+   >>> from sbpy.activity import CircularAperture, AnnularAperture, RectangularAperture, GaussianAperture
+   >>> apertures = (
+   ...   ( '10" radius circle', CircularAperture(10 * u.arcsec)),
+   ...   (    '5"–10" annulus', AnnularAperture([5, 10] * u.arcsec)),
+   ...   (       '2"x10" slit', RectangularAperture([2, 10] * u.arcsec)),
+   ...   ('σ=5" Gaussian beam', GaussianAperture(5 * u.arcsec))
+   ... )
+   >>> for name, aper in apertures:
+   ...     afrho = Afrho.from_fluxd('λ5240', flam, aper, eph)
+   ...     print('{:18s} = {:5.0f}'.format(name, afrho))    # doctest: +FLOAT_CMP
    10" radius circle =  5917 cm
       5"–10" annulus = 11834 cm
          2"x10" slit = 28114 cm
-  σ=5" Gaussian beam =  9442 cm
+   σ=5" Gaussian beam =  9442 cm
 
 
 Reference/API

--- a/docs/sbpy/calib.rst
+++ b/docs/sbpy/calib.rst
@@ -18,26 +18,26 @@ Each star has a class for use within sbpy.  The classes can be initialized with 
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Sun
-  >>> sun = Sun.from_default()
-  >>> print(sun)
-  <Sun: E490-00a (2014) reference solar spectrum (Table 3)>
+    >>> from sbpy.calib import Sun
+    >>> sun = Sun.from_default()
+    >>> print(sun)
+    <Sun: E490-00a (2014) reference solar spectrum (Table 3)>
 
 The names of the built-in sources are stored as an internal array.  They can be discovered with :func:`~sbpy.calib.SpectralStandard.show_builtin`, and used to initialize an object with :func:`~sbpy.calib.SpectralStandard.from_builtin`:
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Sun
-  >>> Sun.show_builtin()
-      name                                description
-  ------------ -----------------------------------------------------------------
-  Castelli1996      Castelli model, scaled and presented by Colina et al. (1996)
-     E490_2014                E490-00a (2014) reference solar spectrum (Table 3)
-   E490_2014LR E490-00a (2014) low resolution reference solar spectrum (Table 4)
-    Kurucz1993               Kurucz (1993) model, scaled by Colina et al. (1996)
-  >>> sun = Sun.from_builtin('E490_2014LR')
-  >>> print(sun)
-  <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>
+    >>> from sbpy.calib import Sun
+    >>> Sun.show_builtin()
+        name                                description
+    ------------ -----------------------------------------------------------------
+    Castelli1996      Castelli model, scaled and presented by Colina et al. (1996)
+        E490_2014                E490-00a (2014) reference solar spectrum (Table 3)
+    E490_2014LR E490-00a (2014) low resolution reference solar spectrum (Table 4)
+        Kurucz1993               Kurucz (1993) model, scaled by Colina et al. (1996)
+    >>> sun = Sun.from_builtin('E490_2014LR')
+    >>> print(sun)
+    <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>
 
 Controlling the default spectra
 -------------------------------
@@ -46,36 +46,36 @@ The Vega and solar spectra in current use are respectively controlled with `~ast
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Sun, solar_spectrum
-  >>> solar_spectrum.set('E490_2014LR')
-  <ScienceState solar_spectrum: <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>>
-  >>> # E490 low-resolution spectrum in effect for all of sbpy
-  >>> sun = Sun.from_default()
-  >>> print(sun)
-  <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>
+    >>> from sbpy.calib import Sun, solar_spectrum
+    >>> solar_spectrum.set('E490_2014LR')
+    <ScienceState solar_spectrum: <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>>
+    >>> # E490 low-resolution spectrum in effect for all of sbpy
+    >>> sun = Sun.from_default()
+    >>> print(sun)
+    <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>
 
 `~sbpy.calib.vega_spectrum` and `~sbpy.calib.solar_spectrum` can also be used as a context manager to temporarily change the default spectrum:
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Sun, solar_spectrum
-  >>> solar_spectrum.set('E490_2014')  # E490 in effect
-  <ScienceState solar_spectrum: <Sun: E490-00a (2014) reference solar spectrum (Table 3)>>
-  >>> with solar_spectrum.set('E490_2014LR'):
-  ...   # E490 low-res in effect
-  ...   print(Sun.from_default())
-  <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>
-  >>> # Back to module default.
-  >>> print(Sun.from_default())
-  <Sun: E490-00a (2014) reference solar spectrum (Table 3)>
+    >>> from sbpy.calib import Sun, solar_spectrum
+    >>> solar_spectrum.set('E490_2014')  # E490 in effect
+    <ScienceState solar_spectrum: <Sun: E490-00a (2014) reference solar spectrum (Table 3)>>
+    >>> with solar_spectrum.set('E490_2014LR'):
+    ...   # E490 low-res in effect
+    ...   print(Sun.from_default())
+    <Sun: E490-00a (2014) low resolution reference solar spectrum (Table 4)>
+    >>> # Back to module default.
+    >>> print(Sun.from_default())
+    <Sun: E490-00a (2014) reference solar spectrum (Table 3)>
 
 Provide your own solar spectrum with the `~sbpy.calib.Sun` class:
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Sun, solar_spectrum
-  >>> with solar_spectrum.set(Sun.from_file('sun.txt')):  # doctest: +SKIP
-  ...   # sun.txt in effect
+    >>> from sbpy.calib import Sun, solar_spectrum
+    >>> with solar_spectrum.set(Sun.from_file('sun.txt')):  # doctest: +SKIP
+    ...   # sun.txt in effect
 
 See `~sbpy.calib.Sun` for more information on ways to create solar spectra.
 
@@ -83,11 +83,11 @@ An example showing how to change the default Vega spectrum:
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Vega, vega_spectrum
-  >>> print(Vega.from_default())     # doctest: +SKIP
-  <Vega: Dust-free template spectrum of Bohlin 2014>
-  >>> with vega_spectrum.set(Vega.from_file('vega.txt')):  # doctest: +SKIP
-  ...   # vega.txt in effect
+    >>> from sbpy.calib import Vega, vega_spectrum
+    >>> print(Vega.from_default())     # doctest: +SKIP
+    <Vega: Dust-free template spectrum of Bohlin 2014>
+    >>> with vega_spectrum.set(Vega.from_file('vega.txt')):  # doctest: +SKIP
+    ...   # vega.txt in effect
 
 
 Photometric calibration (without spectra or `synphot`)
@@ -97,61 +97,61 @@ The `~astropy.utils.state.ScienceState` objects `~sbpy.calib.solar_fluxd` and `~
 
 .. testsetup::
 .. doctest-requires:: astropy<5.3
-  
-  >>> from sbpy.calib import Sun, solar_fluxd, vega_fluxd
-  >>> import sbpy.units as sbu
 
-.. doctest-requires:: astropy>=5.3
+    >>> from sbpy.calib import Sun, solar_fluxd, vega_fluxd
+    >>> import sbpy.units as sbu
 
-  >>> from sbpy.calib import Sun, solar_fluxd, vega_fluxd
-  >>> import sbpy.units as sbu
-  >>>
-  >>> solar_fluxd.set('Willmer2018')   # doctest: +IGNORE_OUTPUT
-  >>> sun = Sun(None)
-  >>> print(sun.observe('PS1 r'))    # doctest: +FLOAT_CMP
-  167.49428760264365 erg / (Angstrom s cm2)
-  >>> vega_fluxd.set('Willmer2018')   # doctest: +IGNORE_OUTPUT
-  >>> print(sun.observe('PS1 r', unit=sbu.VEGAmag))    # doctest: +FLOAT_CMP
-  -27.05 mag(VEGA)
+    .. doctest-requires:: astropy>=5.3
+
+    >>> from sbpy.calib import Sun, solar_fluxd, vega_fluxd
+    >>> import sbpy.units as sbu
+    >>>
+    >>> solar_fluxd.set('Willmer2018')   # doctest: +IGNORE_OUTPUT
+    >>> sun = Sun(None)
+    >>> print(sun.observe('PS1 r'))    # doctest: +FLOAT_CMP
+    167.49428760264365 erg / (Angstrom s cm2)
+    >>> vega_fluxd.set('Willmer2018')   # doctest: +IGNORE_OUTPUT
+    >>> print(sun.observe('PS1 r', unit=sbu.VEGAmag))    # doctest: +FLOAT_CMP
+    -27.05 mag(VEGA)
 
 Use ``solar_fluxd.get('Willmer2018')`` to discover all built-in values.
 
 Users wanting to calibrate data with their own flux densities may do so.  For example, set the *V*-band apparent magnitude of the Sun to that in Colina et al. (1996).  Observations through the ``'V'`` filter will use the specified value:
 
-  >>> solar_fluxd.set({'V': -26.75 * sbu.VEGAmag})  # doctest: +IGNORE_OUTPUT
-  >>> sun = Sun.from_default()
-  >>> print(sun.observe('V'))
-  -26.75 mag(VEGA)
+    >>> solar_fluxd.set({'V': -26.75 * sbu.VEGAmag})  # doctest: +IGNORE_OUTPUT
+    >>> sun = Sun.from_default()
+    >>> print(sun.observe('V'))
+    -26.75 mag(VEGA)
 
 Some sbpy calculations will require the effective wavelength or the pivot wavelength.  These are optional parameters that may be specified with `~sbpy.calib.solar_fluxd` and `~sbpy.calib.vega_fluxd`:
 
 .. doctest-requires:: astropy>=5.3
 
-  >>> import astropy.units as u
-  >>> from sbpy.calib import vega_fluxd, Vega
-  >>>
-  >>> # values from Willmer (2018)
-  >>> vega_fluxd.set({
-  ...     'V': 3674.73 * u.Jy,
-  ...     'V(lambda eff)': 5476 * u.AA
-  ... })    # doctest: +IGNORE_OUTPUT
-  <ScienceState vega_fluxd: {'V': <Quantity 3674.73 Jy>, 'V(lambda eff)': <Quantity 5476. Angstrom>}>
-  >>> vega = Vega.from_default()
-  >>> print(vega.observe('V'))
-  3674.73 Jy
-  >>> print(vega.observe('V', unit='erg/(s cm2 AA)'))
-  ...     # doctest: +IGNORE_EXCEPTION_DETAIL
-  Traceback (most recent call last):
-  ...
-  UnitConversionError: 'Jy' (spectral flux density) and 'erg / (Angstrom s cm2)' (spectral flux density wav) are not convertible  Is "V(lambda pivot)" required and was it provided?
-  >>> vega_fluxd.set({
-  ...     'V': 3674.73 * u.Jy,
-  ...     'V(lambda eff)': 5476 * u.AA,
-  ...     'V(lambda pivot)': 5511 * u.AA
-  ... })    # doctest: +IGNORE_OUTPUT
-  <ScienceState vega_fluxd: {'V': <Quantity 3674.73 Jy>, 'V(lambda eff)': <Quantity 5476. Angstrom>, 'V(lambda pivot)': <Quantity 5511. Angstrom>}>
-  >>> print(vega.observe('V', unit='erg/(s cm2 AA)'))   # doctest: +FLOAT_CMP
-  3.62701e-9 erg / (Angstrom s cm2)
+    >>> import astropy.units as u
+    >>> from sbpy.calib import vega_fluxd, Vega
+    >>>
+    >>> # values from Willmer (2018)
+    >>> vega_fluxd.set({
+    ...     'V': 3674.73 * u.Jy,
+    ...     'V(lambda eff)': 5476 * u.AA
+    ... })    # doctest: +IGNORE_OUTPUT
+    <ScienceState vega_fluxd: {'V': <Quantity 3674.73 Jy>, 'V(lambda eff)': <Quantity 5476. Angstrom>}>
+    >>> vega = Vega.from_default()
+    >>> print(vega.observe('V'))
+    3674.73 Jy
+    >>> print(vega.observe('V', unit='erg/(s cm2 AA)'))
+    ...     # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    UnitConversionError: 'Jy' (spectral flux density) and 'erg / (Angstrom s cm2)' (spectral flux density wav) are not convertible  Is "V(lambda pivot)" required and was it provided?
+    >>> vega_fluxd.set({
+    ...     'V': 3674.73 * u.Jy,
+    ...     'V(lambda eff)': 5476 * u.AA,
+    ...     'V(lambda pivot)': 5511 * u.AA
+    ... })    # doctest: +IGNORE_OUTPUT
+    <ScienceState vega_fluxd: {'V': <Quantity 3674.73 Jy>, 'V(lambda eff)': <Quantity 5476. Angstrom>, 'V(lambda pivot)': <Quantity 5511. Angstrom>}>
+    >>> print(vega.observe('V', unit='erg/(s cm2 AA)'))   # doctest: +FLOAT_CMP
+    3.62701e-9 erg / (Angstrom s cm2)
 
 Observe the Sun
 ---------------
@@ -162,15 +162,15 @@ Get the default solar spectrum, observe it through the Johnson V-band filter (di
 
 .. doctest-requires:: synphot
 
-  >>> from sbpy.calib import Sun
-  >>> from sbpy.photometry import bandpass
-  >>> from sbpy.units import JMmag
-  >>>
-  >>> sun = Sun.from_default()
-  >>> bp = bandpass('Johnson V')
-  >>> fluxd = sun.observe(bp, unit=JMmag)
-  >>> print(fluxd)    # doctest: +FLOAT_CMP
-  -26.744715028702647 mag(JM)
+    >>> from sbpy.calib import Sun
+    >>> from sbpy.photometry import bandpass
+    >>> from sbpy.units import JMmag
+    >>>
+    >>> sun = Sun.from_default()
+    >>> bp = bandpass('Johnson V')
+    >>> fluxd = sun.observe(bp, unit=JMmag)
+    >>> print(fluxd)    # doctest: +FLOAT_CMP
+    -26.744715028702647 mag(JM)
 
 
 Binning versus interpolation with ``observe()``
@@ -182,43 +182,43 @@ When the requested spectral resolution is comparable to the spectral resolution 
 
 Compare interpolation and rebinning for the E490 low-resolution solar spectrum, using the stored wavelengths of the spectrum.  Initialize a `~sbpy.calib.Sun` object with the low-resolution spectrum.
 
-  >>> import numpy as np
-  >>> from sbpy.calib import Sun
-  >>> sun = Sun.from_builtin('E490_2014LR')
+    >>> import numpy as np
+    >>> from sbpy.calib import Sun
+    >>> sun = Sun.from_builtin('E490_2014LR')
 
 Inspect a sub-set of the data for this example.
 
 .. doctest-requires:: astropy>=5.3
-  
-  >>> wave = sun.wave[430:435]
-  >>> S = sun.fluxd[430:435]
-  >>> print(wave)    # doctest: +FLOAT_CMP
-  [5495. 5505. 5515. 5525. 5535.] Angstrom
-  >>> print(S)       # doctest: +FLOAT_CMP
-  [1895. 1862. 1871. 1846. 1882.] W / (um m2)
+
+    >>> wave = sun.wave[430:435]
+    >>> S = sun.fluxd[430:435]
+    >>> print(wave)    # doctest: +FLOAT_CMP
+    [5495. 5505. 5515. 5525. 5535.] Angstrom
+    >>> print(S)       # doctest: +FLOAT_CMP
+    [1895. 1862. 1871. 1846. 1882.] W / (um m2)
 
 Interpolate with observe() and compare to the original values.
 
 .. testsetup::
 .. doctest-requires:: astropy<5.3
 
-  >>> wave = sun.wave[430:435]
-  >>> S = sun.fluxd[430:435]  # for astropy<5.3
+    >>> wave = sun.wave[430:435]
+    >>> S = sun.fluxd[430:435]
 
-  >>> S_interp = sun.observe(wave, interpolate=True)
-  >>> np.allclose(S.value, S_interp.value)
-  True
+    >>> S_interp = sun.observe(wave, interpolate=True)
+    >>> np.allclose(S.value, S_interp.value)
+    True
 
 Re-bin with observe using the same wavelengths as band centers.
 
-  >>> S_rebin = sun.observe(wave)
-  >>> np.allclose(S.value, S_rebin.value)
-  False
+    >>> S_rebin = sun.observe(wave)
+    >>> np.allclose(S.value, S_rebin.value)
+    False
 
 Inspect the differences.
 
-  >>> print((S_rebin - S) / (S_rebin + S) * 2)    # doctest: +FLOAT_CMP
-  [-0.00429693  0.00281266 -0.00227604  0.00412338 -0.00132301]
+    >>> print((S_rebin - S) / (S_rebin + S) * 2)    # doctest: +FLOAT_CMP
+    [-0.00429693  0.00281266 -0.00227604  0.00412338 -0.00132301]
 
 
 Plot solar spectra
@@ -228,46 +228,46 @@ Solar spectra in Sun objects can be plotted at the native resolution of the data
 
 .. doctest-skip::
 
-  >>> import astropy.units as u
-  >>> import numpy as np
-  >>> import matplotlib.pyplot as plt
-  >>> from sbpy.calib import Sun
-  >>> # Create an array of wavelengths at R~25
-  >>> wrange = 0.3, 0.8  # wavelength range
-  >>> d = 1 + 1 / 25
-  >>> n = int(np.ceil(np.log(wrange[1] / wrange[0]) / np.log(d)))
-  >>> wave_binned = wrange[0] * d**np.arange(n) * u.um
-  >>> # Get the default solar spectrum, and rebin it
-  >>> sun = Sun.from_default()
-  >>> fluxd_binned = sun.observe(wave_binned, unit='W / (m2 um)')
-  >>> # Plot
-  >>> plt.plot(sun.wave.to('um'), sun.fluxd.to('W/(m2 um)'),
-  ...          drawstyle='steps-mid', color='#1f77b4',
-  ...          label='Native resolution')
-  >>> plt.plot(wave_binned, fluxd_binned, drawstyle='steps-mid',
-  ...          color='#ff7f0e', label='R~25')
-  >>> plt.setp(plt.gca(), xlim=wrange, xlabel='Wavelength (μm)',
-  ...          ylabel='Flux density (W/(m2 μm)')
-  >>> plt.legend()
-  >>> plt.tight_layout()
+    >>> import astropy.units as u
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from sbpy.calib import Sun
+    >>> # Create an array of wavelengths at R~25
+    >>> wrange = 0.3, 0.8  # wavelength range
+    >>> d = 1 + 1 / 25
+    >>> n = int(np.ceil(np.log(wrange[1] / wrange[0]) / np.log(d)))
+    >>> wave_binned = wrange[0] * d**np.arange(n) * u.um
+    >>> # Get the default solar spectrum, and rebin it
+    >>> sun = Sun.from_default()
+    >>> fluxd_binned = sun.observe(wave_binned, unit='W / (m2 um)')
+    >>> # Plot
+    >>> plt.plot(sun.wave.to('um'), sun.fluxd.to('W/(m2 um)'),
+    ...          drawstyle='steps-mid', color='#1f77b4',
+    ...          label='Native resolution')
+    >>> plt.plot(wave_binned, fluxd_binned, drawstyle='steps-mid',
+    ...          color='#ff7f0e', label='R~25')
+    >>> plt.setp(plt.gca(), xlim=wrange, xlabel='Wavelength (μm)',
+    ...          ylabel='Flux density (W/(m2 μm)')
+    >>> plt.legend()
+    >>> plt.tight_layout()
 
 .. plot::
 
-  import astropy.units as u
-  import numpy as np
-  import matplotlib.pyplot as plt
-  from sbpy.calib import Sun
-  wrange = 0.3, 0.8  # wavelength range
-  d = 1 + 1 / 25
-  n = int(np.ceil(np.log(wrange[1] / wrange[0]) / np.log(d)))
-  wave_binned = wrange[0] * d**np.arange(n) * u.um
-  sun = Sun.from_default()
-  fluxd_binned = sun.observe(wave_binned, unit='W / (m2 um)')
-  plt.plot(sun.wave.to('um'), sun.fluxd.to('W/(m2 um)'), drawstyle='steps-mid', color='#1f77b4', label='Native resolution')
-  plt.plot(wave_binned, fluxd_binned, drawstyle='steps-mid', color='#ff7f0e', label='R~25')
-  plt.setp(plt.gca(), xlim=wrange, xlabel='Wavelength (μm)', ylabel='Flux density (W/(m2 μm)')
-  plt.legend()
-  plt.tight_layout()
+    import astropy.units as u
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from sbpy.calib import Sun
+    wrange = 0.3, 0.8  # wavelength range
+    d = 1 + 1 / 25
+    n = int(np.ceil(np.log(wrange[1] / wrange[0]) / np.log(d)))
+    wave_binned = wrange[0] * d**np.arange(n) * u.um
+    sun = Sun.from_default()
+    fluxd_binned = sun.observe(wave_binned, unit='W / (m2 um)')
+    plt.plot(sun.wave.to('um'), sun.fluxd.to('W/(m2 um)'), drawstyle='steps-mid', color='#1f77b4', label='Native resolution')
+    plt.plot(wave_binned, fluxd_binned, drawstyle='steps-mid', color='#ff7f0e', label='R~25')
+    plt.setp(plt.gca(), xlim=wrange, xlabel='Wavelength (μm)', ylabel='Flux density (W/(m2 μm)')
+    plt.legend()
+    plt.tight_layout()
 
 
 Reference/API

--- a/docs/sbpy/data/obs.rst
+++ b/docs/sbpy/data/obs.rst
@@ -8,7 +8,7 @@ Observational Data Objects (`sbpy.data.Obs`)
 For instance, this class allows you to query observations reported to the Minor
 Planet Center for a given target via `astroquery.mpc.MPCClass.get_observations`:
 
-  .. doctest-remote-data:: 
+.. doctest-remote-data:: 
 
     >>> from sbpy.data import Obs
     >>> data = Obs.from_mpc('2019 AA', id_type='asteroid designation')
@@ -37,7 +37,7 @@ function makes use of the query functions that are part of
 `~sbpy.data.Ephem` and allows you to pick a service from which you
 would like to obtain the data.
 
-  .. doctest-remote-data:: 
+.. doctest-remote-data:: 
 
     >>> data.field_names
     ['number', 'desig', 'discovery', 'note1', 'note2', 'epoch', 'RA', 'DEC', 'mag', 'band', 'observatory']


### PR DESCRIPTION
Some directives were ignored because they were incorrectly indented, which caused a remote test to run without permission.