### PR TITLE
Avoid a dirty git index with readthedocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ distribute-*.tar.gz
 *py#
 .firebase
 .tmp
+coverage.xml
 
 # Mac OSX
 .DS_Store

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,12 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.10"
   apt_packages:
     - graphviz
+  jobs:
+    pre_install:
+      - git update-index --assume-unchanged docs/conf.py
 
 sphinx:
   builder: html


### PR DESCRIPTION
Following discussion at #377 , this PR attempts to fix the version in RTD's "latest" documentation: https://sbpy.readthedocs.io/en/latest