### PR TITLE
Astropy updates 2023.07

### DIFF
--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -17,7 +17,6 @@ import abc
 
 import numpy as np
 import astropy.units as u
-import astropy.version as astropy_version
 
 try:
     from astropy.utils.misc import InheritDocstrings
@@ -309,18 +308,7 @@ def phase_HalleyMarcus(phase):
     return Phi
 
 
-# checks if the installed astropy version is up-to-date
-if astropy_version.major < 4:
-
-    class DustComaQuantityMeta(InheritDocstrings, abc.ABCMeta):
-        pass
-
-else:
-    # astropy >= 4.0
-    DustComaQuantityMeta = abc.ABCMeta
-
-
-class DustComaQuantity(u.SpecificTypeQuantity, metaclass=DustComaQuantityMeta):
+class DustComaQuantity(u.SpecificTypeQuantity, metaclass=abc.ABCMeta):
     """Abstract base class for dust coma photometric models: Afrho, Efrho."""
 
     _equivalent_unit = u.meter

--- a/sbpy/conftest.py
+++ b/sbpy/conftest.py
@@ -9,21 +9,13 @@ packagename.test
 
 import os
 
-from astropy.version import version as astropy_version
-
-# For Astropy 3.0 and later, we can use the standalone pytest plugin
-if astropy_version < '3.0':
-    from astropy.tests.pytest_plugins import *  # noqa
-    del pytest_report_header
+try:
+    from pytest_astropy_header.display import (
+        PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    )
     ASTROPY_HEADER = True
-else:
-    try:
-        from pytest_astropy_header.display import (
-            PYTEST_HEADER_MODULES, TESTED_VERSIONS
-        )
-        ASTROPY_HEADER = True
-    except ImportError:
-        ASTROPY_HEADER = False
+except ImportError:
+    ASTROPY_HEADER = False
 
 
 def pytest_configure(config):

--- a/sbpy/conftest.py
+++ b/sbpy/conftest.py
@@ -39,16 +39,3 @@ def pytest_configure(config):
         from . import __version__
         packagename = os.path.basename(os.path.dirname(__file__))
         TESTED_VERSIONS[packagename] = __version__
-
-# Uncomment the last two lines in this block to treat all DeprecationWarnings
-# as exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-# as follow (although default should work for most cases).
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python version
-# MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-# from astropy.tests.helper import enable_deprecations_as_exceptions  # noqa
-# enable_deprecations_as_exceptions()


### PR DESCRIPTION
Currently supported astropy is >=4.3.  Remove code branches for astropy < 4.  Remove commented out reference to a deprecated astropy method.