### PR TITLE
Limit dependencies to strictly necessary packages.

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -45,10 +45,10 @@ jobs:
 
         - name: Python 3.10 with all optional dependencies, measuring coverage
           linux: py310-test-alldeps-cov
+          coverage: codecov
           
         - name: Python 3.8 with oldest supported versions
           linux: py38-test-oldestdeps
-          coverage: codecov
 
   macos-tests:
     name: Python 3.10 with all optional dependencies (MacOS)

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -7,9 +7,9 @@ name: CI Tests
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - '*'
+      - "*"
   pull_request:
     # branches: # only build on PRs against 'main' if you need to further limit when CI is run.
     #    - main
@@ -34,17 +34,17 @@ jobs:
         ARCH_ON_CI: "normal"
         IS_CRON: "false"
       submodules: false
-      coverage: ''
+      coverage: ""
       envs: |
         - name: Code style checks
           linux: codestyle
 
-        - name: Python 3.11 with minimal dependencies and full coverage
+        - name: Python 3.11 with minimal dependencies, measuring coverage
           linux: py311-test-cov
           coverage: codecov
 
-        - name: Python 3.10 with all optional dependencies
-          linux: py310-test-alldeps
+        - name: Python 3.10 with all optional dependencies, measuring coverage
+          linux: py310-test-alldeps-cov
           
         - name: Python 3.8 with oldest supported versions
           linux: py38-test-oldestdeps
@@ -56,23 +56,23 @@ jobs:
     env:
       ARCH_ON_CI: "normal"
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - name: Set up gfortran on ${{ matrix.os }}
-      if: runner.os == 'macos'
-      run: |
-        echo `which gfortran-11`
-        sudo ln -sfn /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-        gfortran --version
-    - name: Install base dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Test with tox
-      run: tox -e py310-test-alldeps
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set up gfortran on ${{ matrix.os }}
+        if: runner.os == 'macos'
+        run: |
+          echo `which gfortran-11`
+          sudo ln -sfn /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+          gfortran --version
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Test with tox
+        run: tox -e py310-test-alldeps

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,39 @@
+0.4.1 (unreleased)
+==================
+
+- Revised required and optional packages:
+  - Only numpy and astropy are required; synphot, ads, and astroquery are now optional dependences.
+  - Created an option to install a recommended list of packages, e.g., ``pip install sbpy[recommended]``.
+
+
+New Features
+------------
+
+sbpy.utils.decorators
+^^^^^^^^^^^^^^^^^^^^^
+
+- Added the `requires` function decorator to test for the presence of optional
+  packages.
+
+- Added the  `optional` function decorator to test for the presence of optional
+  packages.
+
+
+API Changes
+-----------
+
+sbpy.sources
+^^^^^^^^^^^^
+* Deprecated ``SynphotRequired``.  Use ``sbpy.execptions.RequiredPackageUnavailable``.
+
+
+Bug Fixes
+---------
+* ``sbpy.sources.SpectralSource`` now correctly raises
+  ``RequiredPackageUnavailable`` when ``synphot`` is not available, replacing a
+  locally defined ``SynphotRequired`` or the generic ``ImportError``.
+
+
 0.4.0 (2023-06-30)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,22 +1,29 @@
-0.4.1 (unreleased)
+0.5.0 (unreleased)
 ==================
 
 - Revised required and optional packages:
-  - Only numpy and astropy are required; synphot, ads, and astroquery are now optional dependences.
-  - Created an option to install a recommended list of packages, e.g., ``pip install sbpy[recommended]``.
+
+  - Only numpy and astropy are required; scipy, synphot, ads, and astroquery are
+    now optional dependences.
+
+  - Created an option to install a recommended list of packages, e.g., ``pip
+    install sbpy[recommended]``.
 
 
 New Features
 ------------
 
+sbpy.utils
+^^^^^^^^^^
+
+- New `required_packages` and `optional_packages` functions to test for the
+  presence of required and optional packages.
+
 sbpy.utils.decorators
 ^^^^^^^^^^^^^^^^^^^^^
 
-- Added the `requires` function decorator to test for the presence of optional
-  packages.
-
-- Added the  `optional` function decorator to test for the presence of optional
-  packages.
+- New `requires` and  `optionally_uses` function decorators to simplify testing
+  for required and optional packages.
 
 
 API Changes

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -122,8 +122,11 @@ Technical requirements
   ultimately be derived from the base classes in `sbpy.exceptions`
 * if you use `~sbpy.data.DataClass` objects, extend the :ref:`field
   name list` list where it makes sense
-* consider using the `sbpy.utils.decorators.requires` decorator to test for the
-  presence of optional dependencies.
+* consider using the `sbpy.utils.decorators.requires` or
+  `sbpy.utils.decorators.optional` decorators to test for the presence of
+  optional dependencies.
+  * `~sbpy.utils.decorators.requires` raises an exception if a package cannot be imported.
+  * `~sbpy.utils.decorators.optional` warns the user if a package cannot be imported.
 * a CHANGELOG entry is required as of v0.2; update the :doc:`/status`
   where applicable
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -124,8 +124,8 @@ Technical requirements
   name list` list where it makes sense
 * consider using the sbpy function and decorator helpers to test for the
   presence of optional dependencies:
-  * `~sbpy.utils.requires` and `~sbpy.utils.decorators.requires` raise an exception if a package cannot be imported.
-  * `~sbpy.utils.optional` and `~sbpy.utils.decorators.optional` warn the user if a package cannot be imported.
+  * `~sbpy.utils.required_packages` and `~@sbpy.utils.decorators.requires` raise an exception if a package cannot be imported.
+  * `~sbpy.utils.optional_packages` and `~@sbpy.utils.decorators.optionally_uses` warn the user if a package cannot be imported.
 * a CHANGELOG entry is required; also update the :doc:`/status` where applicable
 
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -121,7 +121,9 @@ Technical requirements
 * customized exceptions and warnings are encouraged, and should
   ultimately be derived from the base classes in `sbpy.exceptions`
 * if you use `~sbpy.data.DataClass` objects, extend the :ref:`field
-  name list` list  where it makes sense
+  name list` list where it makes sense
+* consider using the `sbpy.utils.decorators.requires` decorator to test for the
+  presence of optional dependencies.
 * a CHANGELOG entry is required as of v0.2; update the :doc:`/status`
   where applicable
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -124,10 +124,8 @@ Technical requirements
   name list` list where it makes sense
 * consider using the sbpy function and decorator helpers to test for the
   presence of optional dependencies:
-    * `~sbpy.utils.requires` and `~sbpy.utils.decorators.requires` raise an
-      exception if a package cannot be imported.
-    * `~sbpy.utils.optional` and `~sbpy.utils.decorators.optional` warn the user
-      if a package cannot be imported.
+  * `~sbpy.utils.requires` and `~sbpy.utils.decorators.requires` raise an exception if a package cannot be imported.
+  * `~sbpy.utils.optional` and `~sbpy.utils.decorators.optional` warn the user if a package cannot be imported.
 * a CHANGELOG entry is required; also update the :doc:`/status` where applicable
 
 

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -122,13 +122,13 @@ Technical requirements
   ultimately be derived from the base classes in `sbpy.exceptions`
 * if you use `~sbpy.data.DataClass` objects, extend the :ref:`field
   name list` list where it makes sense
-* consider using the `sbpy.utils.decorators.requires` or
-  `sbpy.utils.decorators.optional` decorators to test for the presence of
-  optional dependencies.
-  * `~sbpy.utils.decorators.requires` raises an exception if a package cannot be imported.
-  * `~sbpy.utils.decorators.optional` warns the user if a package cannot be imported.
-* a CHANGELOG entry is required as of v0.2; update the :doc:`/status`
-  where applicable
+* consider using the sbpy function and decorator helpers to test for the
+  presence of optional dependencies:
+    * `~sbpy.utils.requires` and `~sbpy.utils.decorators.requires` raise an
+      exception if a package cannot be imported.
+    * `~sbpy.utils.optional` and `~sbpy.utils.decorators.optional` warn the user
+      if a package cannot be imported.
+* a CHANGELOG entry is required; also update the :doc:`/status` where applicable
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,10 +25,10 @@ Optional dependencies
   rate calculations related to cometary activity (`~sbpy.activity.gas.NonLTE`).
 * `scipy <https://scipy.org/>`__: 1.3 or later, for numerical integrations in `sbpy.activity.gas` and `sbpy.photometry`, among others.  **Recommended**
 * `synphot <https://github.com/spacetelescope/synphot_refactor>`__ 1.1.1 or later, for calibration with respect to the Sun and Vega, filtering spectra through bandpasses.  **Recommended**
-* `ginga <https://ejeschke.github.io/ginga/>`__ and `photutils
-  <https://photutils.readthedocs.io/en/stable/>`__: To interactively enhance
+* `ginga <https://ejeschke.github.io/ginga/>`__ : To interactively enhance
   images of comets with the `~sbpy.imageanalysis.CometaryEnhancement` Ginga
   plugin.
+* `photutils <https://photutils.readthedocs.io/en/stable/>`__: For centroiding within the Cometary Enhancements Ginga plugin.
 
 
 Using pip

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,22 +9,22 @@ Requirements
 care of with installation using pip:
 
 * Python 3.8 or later
-* `ads <https://github.com/andycasey/ads/>`__ 0.12 or later, to fetch citation details for bibliography tracking.
 * `astropy <https://www.astropy.org/>`__ 4.3 or later.
-* `astroquery <https://astroquery.readthedocs.io/en/latest/>`__ 0.4.5 or later, for retrieval of online data, e.g., ephemerides and orbits.
 * `numpy <https://numpy.org/>`__ 1.18 or later.
-* `scipy <https://scipy.org/>`__: 1.3 or later, for numerical integrations in `sbpy.activity.gas` and `sbpy.photometry`, among others.
-* `synphot <https://github.com/spacetelescope/synphot_refactor>`__ 1.1.1 or later, for calibration with respect to the Sun and Vega, filtering spectra through bandpasses.
 
 Optional dependencies
 ^^^^^^^^^^^^^^^^^^^^^
 
+* `ads <https://github.com/andycasey/ads/>`__ 0.12 or later, to fetch citation details for bibliography tracking.  **Recommended**
+* `astroquery <https://astroquery.readthedocs.io/en/latest/>`__ 0.4.5 or later, for retrieval of online data, e.g., ephemerides and orbits.  **Recommended**
 * Python extensions for `oorb <https://github.com/oorb/oorb/>`__: For orbit
   transformations (`~sbpy.data.Orbit.oo_transform`) and propagations
   (`~sbpy.data.Orbit.oo_propagate`), as well as ephemerides calculations
   (`~sbpy.data.Ephem.from_oo`).
 * `pyradex <https://github.com/keflavich/pyradex>`__: For non-LTE production
   rate calculations related to cometary activity (`~sbpy.activity.gas.NonLTE`).
+* `scipy <https://scipy.org/>`__: 1.3 or later, for numerical integrations in `sbpy.activity.gas` and `sbpy.photometry`, among others.  **Recommended**
+* `synphot <https://github.com/spacetelescope/synphot_refactor>`__ 1.1.1 or later, for calibration with respect to the Sun and Vega, filtering spectra through bandpasses.  **Recommended**
 * `ginga <https://ejeschke.github.io/ginga/>`__ and `photutils
   <https://photutils.readthedocs.io/en/stable/>`__: To interactively enhance
   images of comets with the `~sbpy.imageanalysis.CometaryEnhancement` Ginga
@@ -39,6 +39,12 @@ The latest stable version of `sbpy` can be installed with:
 .. code-block:: bash
 
     $ pip install sbpy
+
+Recommended dependencies may be installed via:
+
+.. code-block:: bash
+
+    $ pip install sbpy[recommended]
 
 Most optional dependencies may be installed via:
 

--- a/docs/sbpy/activity/dust.rst
+++ b/docs/sbpy/activity/dust.rst
@@ -147,17 +147,23 @@ Phase angles and functions
 
 Phase angle was not used in the previous section.  In the *Afρ* formalism, "albedo" includes the scattering phase function, and is more precisely written *A(θ)*, where *θ* is the phase angle.  The default behavior for `Afrho` is to compute *A(θ)fρ* as opposed to *A(0°)fρ*.  Returning to the A'Hearn et al. data, we scale *Afρ* to 0° from 3.3° phase using the :func:`~sbpy.activity.Afrho.to_phase` method:
 
+.. doctest-requires:: scipy
+
    >>> afrho = Afrho(6029.9 * u.cm)
    >>> print(afrho.to_phase(0 * u.deg, 3.3 * u.deg))    # doctest: +FLOAT_CMP
    6886.825981017757 cm
 
 The default phase function is the Halley-Marcus composite phase function (:func:`~sbpy.activity.phase_HalleyMarcus`).  Any function or callable object that accepts an angle as a `~astropy.units.Quantity` and returns a scalar value may be used:
 
+.. doctest-requires:: scipy
+
    >>> Phi = lambda phase: 10**(-0.016 / u.deg * phase.to('deg'))
    >>> print(afrho.to_phase(0 * u.deg, 3.3 * u.deg, Phi=Phi))    # doctest: +FLOAT_CMP
    6809.419810008357 cm
 
 To correct an observed flux density for the phase function, use the ``phasecor`` option of :func:`~sbpy.activity.Afrho.to_fluxd` and :func:`~sbpy.activity.Afrho.from_fluxd` methods:
+
+.. doctest-requires:: scipy
 
    >>> flam = 10**-13.99 * u.Unit('erg/(s cm2 AA)')
    >>> aper = 27200 * u.km

--- a/docs/sbpy/activity/gas.rst
+++ b/docs/sbpy/activity/gas.rst
@@ -83,6 +83,8 @@ daughter species.  It is included with some calculation enhancements based on
 Newburn and Johnson (1978).  With `~sbpy.activity.gas.Haser`, we may compute the
 column density and total number of molecules within an aperture:
 
+.. doctest-requires:: scipy
+
   >>> Q = 1e28 / u.s        # production rate
   >>> v = 0.8 * u.km / u.s  # expansion speed
   >>> parent = gas.photo_lengthscale('H2O')
@@ -94,6 +96,8 @@ column density and total number of molecules within an aperture:
   1.161357452192558e+30
 
 The gas coma models work with sbpy's apertures:
+
+.. doctest-requires:: scipy
 
   >>> from sbpy.activity import AnnularAperture
   >>> ap = AnnularAperture((5000, 10000) * u.km)
@@ -125,6 +129,8 @@ number of molecules in an aperture.  Parent and daughter data is provided via
 +------------------+-----------+------+-------------------------------------------------------+
 | daughter         | v_photo   | m/s  | photodissociation velocity (v_R)                      |
 +------------------+-----------+------+-------------------------------------------------------+
+
+.. doctest-requires:: scipy
 
   >>> from sbpy.data import Phys
   >>> water = Phys.from_dict({

--- a/docs/sbpy/activity/gas.rst
+++ b/docs/sbpy/activity/gas.rst
@@ -48,6 +48,8 @@ Some sources provide values for the quiet and active Sun (Huebner et al. 1992):
 
 With the :doc:`../bib`, the citation may be discovered:
 
+.. doctest-requires:: ads
+
   >>> from sbpy import bib
   >>> bib.reset()             # clear any old citations
   >>> with bib.Tracking():

--- a/docs/sbpy/calib.rst
+++ b/docs/sbpy/calib.rst
@@ -103,7 +103,7 @@ The `~astropy.utils.state.ScienceState` objects `~sbpy.calib.solar_fluxd` and `~
     >>> from sbpy.calib import Sun, solar_fluxd, vega_fluxd
     >>> import sbpy.units as sbu
 
-    .. doctest-requires:: astropy>=5.3
+.. doctest-requires:: astropy>=5.3
 
     >>> from sbpy.calib import Sun, solar_fluxd, vega_fluxd
     >>> import sbpy.units as sbu
@@ -184,13 +184,15 @@ When the requested spectral resolution is comparable to the spectral resolution 
 
 Compare interpolation and rebinning for the E490 low-resolution solar spectrum, using the stored wavelengths of the spectrum.  Initialize a `~sbpy.calib.Sun` object with the low-resolution spectrum.
 
+.. doctest-requires:: synphot
+
     >>> import numpy as np
     >>> from sbpy.calib import Sun
     >>> sun = Sun.from_builtin('E490_2014LR')
 
 Inspect a sub-set of the data for this example.
 
-.. doctest-requires:: astropy>=5.3
+.. doctest-requires:: astropy>=5.3, synphot
 
     >>> wave = sun.wave[430:435]
     >>> S = sun.fluxd[430:435]
@@ -202,22 +204,25 @@ Inspect a sub-set of the data for this example.
 Interpolate with observe() and compare to the original values.
 
 .. testsetup::
-.. doctest-requires:: astropy<5.3
+.. doctest-requires:: astropy<5.3, synphot
 
     >>> wave = sun.wave[430:435]
     >>> S = sun.fluxd[430:435]
-
     >>> S_interp = sun.observe(wave, interpolate=True)
     >>> np.allclose(S.value, S_interp.value)
     True
 
 Re-bin with observe using the same wavelengths as band centers.
 
+.. doctest-requires:: synphot
+
     >>> S_rebin = sun.observe(wave)
     >>> np.allclose(S.value, S_rebin.value)
     False
 
 Inspect the differences.
+
+.. doctest-requires:: synphot
 
     >>> print((S_rebin - S) / (S_rebin + S) * 2)    # doctest: +FLOAT_CMP
     [-0.00429693  0.00281266 -0.00227604  0.00412338 -0.00132301]

--- a/docs/sbpy/data/ephem.rst
+++ b/docs/sbpy/data/ephem.rst
@@ -16,6 +16,7 @@ query for ephemerides of asteroid Ceres on a given date and for the position of
 Mauna Kea Observatory (IAU observatory code 568) from the `JPL Horizons service
 <https://ssd.jpl.nasa.gov/horizons/>`_:
 
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from sbpy.data import Ephem
@@ -35,6 +36,7 @@ Mauna Kea Observatory (IAU observatory code 568) from the `JPL Horizons service
 The full column name list in the data table can be retrieved with the
 `~sbpy.data.DataClass.field_names` property:
 
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> eph.field_names
@@ -48,7 +50,7 @@ In the above example a specific epoch was specified, but multiple epochs may be
 requested, or even a range of epochs.  All time references are
 `~astropy.time.Time` objects.
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> epochs = Time(['2022-06-04', '2023-06-04'])
@@ -68,7 +70,7 @@ than a few hundred to prevent corruption of the query (see
 
 To specify a range of epochs:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> import astropy.units as u
@@ -98,7 +100,7 @@ Mulitple targets
 An additional feature of `~sbpy.data.Ephem.from_horizons` is that you can
 automatically concatenate queries for a number of objects:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> epoch1 = Time('2018-08-03 14:20')
@@ -133,7 +135,7 @@ codes <https://www.minorplanetcenter.net/iau/lists/ObsCodesF.html>`__ as above,
 or by using `~astropy.coordinates.EarthLocation` as shown in the following
 example:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from astropy.coordinates import EarthLocation
@@ -159,7 +161,7 @@ to `~sbpy.data.Ephem.from_horizons` are directly passed on to
 flexibility of the latter function.  For example one may use the
 ``skip_daylight`` keyword argument:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> epoch1 = Time('2018-08-03 14:20', scale='utc')
@@ -175,7 +177,7 @@ Or, a common option for periodic cometary targets is to limit orbit look-ups to
 the apparition closest to the epochs being queried (requires
 ``id_type='designation'``):
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> eph = Ephem.from_horizons('2P')   # doctest: +SKIP
@@ -202,7 +204,7 @@ Offering similar functionality, the `~sbpy.data.Ephem.from_mpc` method will
 retrieve ephemerides from the `Minor Planet Center's Ephemeris Service
 <https://minorplanetcenter.net/iau/MPEph/MPEph.html>`_:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> eph = Ephem.from_mpc('2P', location='568',
@@ -230,7 +232,7 @@ Finally, `~sbpy.data.Ephem.from_miriade` will retrieve ephemerides from the
 `Institut de Mécanique Céleste et de Calcul des Éphémérides
 <https://www.imcce.fr/>`_:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> eph = Ephem.from_miriade('2P', objtype='comet', location='568',

--- a/docs/sbpy/data/ephem.rst
+++ b/docs/sbpy/data/ephem.rst
@@ -48,6 +48,7 @@ In the above example a specific epoch was specified, but multiple epochs may be
 requested, or even a range of epochs.  All time references are
 `~astropy.time.Time` objects.
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> epochs = Time(['2022-06-04', '2023-06-04'])
@@ -67,6 +68,7 @@ than a few hundred to prevent corruption of the query (see
 
 To specify a range of epochs:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> import astropy.units as u
@@ -96,7 +98,8 @@ Mulitple targets
 An additional feature of `~sbpy.data.Ephem.from_horizons` is that you can
 automatically concatenate queries for a number of objects:
 
-.. doctest-remote-data:: 
+.. doctest-requires:: astroquery
+.. doctest-remote-data::
 
     >>> epoch1 = Time('2018-08-03 14:20')
     >>> eph = Ephem.from_horizons(['Ceres', 'Pallas', 12893, '1983 SA'],
@@ -130,6 +133,7 @@ codes <https://www.minorplanetcenter.net/iau/lists/ObsCodesF.html>`__ as above,
 or by using `~astropy.coordinates.EarthLocation` as shown in the following
 example:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from astropy.coordinates import EarthLocation
@@ -155,6 +159,7 @@ to `~sbpy.data.Ephem.from_horizons` are directly passed on to
 flexibility of the latter function.  For example one may use the
 ``skip_daylight`` keyword argument:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> epoch1 = Time('2018-08-03 14:20', scale='utc')
@@ -170,6 +175,7 @@ Or, a common option for periodic cometary targets is to limit orbit look-ups to
 the apparition closest to the epochs being queried (requires
 ``id_type='designation'``):
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> eph = Ephem.from_horizons('2P')   # doctest: +SKIP
@@ -196,12 +202,13 @@ Offering similar functionality, the `~sbpy.data.Ephem.from_mpc` method will
 retrieve ephemerides from the `Minor Planet Center's Ephemeris Service
 <https://minorplanetcenter.net/iau/MPEph/MPEph.html>`_:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> eph = Ephem.from_mpc('2P', location='568',
     ...                      epochs={'start': Time('2018-10-22'),
     ...                              'stop': Time('2018-10-26'),
-    ...                              'step': 1*u.day})  # doctest: +REMOTE_DATA
+    ...                              'step': 1*u.day})
     >>> eph  # doctest: +SKIP
     <QTable length=5>
     Targetname           Date          ... Moon distance Moon altitude
@@ -223,6 +230,7 @@ Finally, `~sbpy.data.Ephem.from_miriade` will retrieve ephemerides from the
 `Institut de Mécanique Céleste et de Calcul des Éphémérides
 <https://www.imcce.fr/>`_:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> eph = Ephem.from_miriade('2P', objtype='comet', location='568',

--- a/docs/sbpy/data/obs.rst
+++ b/docs/sbpy/data/obs.rst
@@ -8,7 +8,7 @@ Observational Data Objects (`sbpy.data.Obs`)
 For instance, this class allows you to query observations reported to the Minor
 Planet Center for a given target via `astroquery.mpc.MPCClass.get_observations`:
 
-.. doctest-requires:: astroquery
+... .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from sbpy.data import Obs
@@ -38,7 +38,7 @@ function makes use of the query functions that are part of
 `~sbpy.data.Ephem` and allows you to pick a service from which you
 would like to obtain the data.
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> data.field_names

--- a/docs/sbpy/data/obs.rst
+++ b/docs/sbpy/data/obs.rst
@@ -8,6 +8,7 @@ Observational Data Objects (`sbpy.data.Obs`)
 For instance, this class allows you to query observations reported to the Minor
 Planet Center for a given target via `astroquery.mpc.MPCClass.get_observations`:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from sbpy.data import Obs
@@ -37,6 +38,7 @@ function makes use of the query functions that are part of
 `~sbpy.data.Ephem` and allows you to pick a service from which you
 would like to obtain the data.
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> data.field_names

--- a/docs/sbpy/data/orbit.rst
+++ b/docs/sbpy/data/orbit.rst
@@ -166,11 +166,21 @@ planet to be specified simultaneously:
 .. doctest-remote-data::
 
     >>> import numpy as np
-    >>> chariklo = Orbit.from_horizons('chariklo', id_type='name')
-    >>> T = chariklo.tisserand(planet=['599', '699', '799', '899'])
+    >>> import astropy.units as u
+    >>> from astropy.time import Time
+    >>> chariklo = Orbit.from_dict({
+    ...     "e": 0.16778,
+    ...     "a": 15.78694 * u.au,
+    ...     "incl": 23.39153 * u.deg,
+    ...     "Omega": 300.44770 * u.deg,
+    ...     "w": 242.01787 * u.deg,
+    ...     "n": 0.015713 * u.deg / u.day,
+    ...     "M":  113.36375 * u.deg,
+    ... })
+    >>> T = chariklo.tisserand(planet=['599', '699', '799', '899'], epoch=Time("2023-08-25"))
     >>> with np.printoptions(precision=3):
     ...     print(T)  # doctest: +FLOAT_CMP
-    [3.485 2.931 2.858 3.224]
+    [3.482 2.93  2.859 3.225]
 
 `~sbpy.Orbit` also provides a method to compare the orbits of two objects
 in terms of the "D-criterion" (`Jopek 1993 <https://ui.adsabs.harvard.edu/abs/1993Icar..106..603J/abstract>`_).  The `~sbpy.Orbit.D_criterion` method
@@ -183,16 +193,37 @@ D_criterion:
 .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
-    >>> comets = Orbit.from_horizons(['252P', 'P/2016 BA14'],
-    ...     id_type='designation', closest_apparition=True)
+    >>> import numpy as np
+    >>> import astropy.units as u
+    >>> from astropy.time import Time
+    >>>
+    >>> comet_252P = Orbit.from_dict({  # P/2016 BA14
+    ...     "e": 0.67309,
+    ...     "q": 0.99605 * u.au,
+    ...     "incl": 10.42220 * u.deg,
+    ...     "Omega": 190.94850 * u.deg,
+    ...     "w": 343.31047 * u.deg,
+    ...     "n": 0.18533 * u.deg / u.day,
+    ...     "Tp": Time("2016-03-15 06:19:30", scale="tdb")
+    ... })
+    >>>
+    >>> comet_460P = Orbit.from_dict({  # P/2016 BA14
+    ...     "e": 0.66625,
+    ...     "q": 1.00858 * u.au,
+    ...     "incl": 18.91867 * u.deg,
+    ...     "Omega": 180.53368 * u.deg,
+    ...     "w": 351.89672 * u.deg,
+    ...     "n": 0.18761 * u.deg / u.day,
+    ...     "Tp": Time("2016-03-15 12:24:19", scale="tdb")
+    ... })
     >>>
     >>> # Southworth & Hawkins function
-    >>> D_SH = comets[0].D_criterion(comets[1])
+    >>> D_SH = comet_252P.D_criterion(comet_460P)
     >>> # Drummond function
-    >>> D_D = comets[0].D_criterion(comets[1], version='d')
+    >>> D_D = comet_252P.D_criterion(comet_460P, version='d')
     >>> # hybrid function
-    >>> D_H = comets[0].D_criterion(comets[1], version='h')
+    >>> D_H = comet_252P.D_criterion(comet_460P, version='h')
     >>> print('D_SH = {:.4f}, D_D = {:.4f}, D_H = {:.4f}'.
     ...    format(D_SH, D_D, D_H))
-    D_SH = 0.1560, D_D = 0.0502, D_H = 0.1556
+    D_SH = 0.1562, D_D = 0.0503, D_H = 0.1558
 

--- a/docs/sbpy/data/orbit.rst
+++ b/docs/sbpy/data/orbit.rst
@@ -9,7 +9,7 @@ Orbit Queries
 body osculating elements from the `JPL Horizons service
 <https://ssd.jpl.nasa.gov/horizons/>`_:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> from sbpy.data import Orbit
@@ -31,7 +31,7 @@ scale of the desired epoch is not supported by the query function and
 hence converted to a scale that is supported (``tdb`` in this case).
 The following fields are available in this object:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> elem.field_names
@@ -44,7 +44,7 @@ epoch (current time) are queried. Similar to
 parameter on to that function. Furthermore, it is possible to query
 orbital elements for a number of targets:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> epoch = Time('2018-08-03 14:20', scale='tdb')
@@ -64,7 +64,7 @@ Alternatively, orbital elements can also be queried from the `Minor
 Planet Center <https://minorplanetcenter.net/iau/MPEph/MPEph.html>`_,
 although in this case only the most recent elements are accessible:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> elem = Orbit.from_mpc(['3552', '12893'])
@@ -93,7 +93,7 @@ using `OpenOrb <https://github.com/oorb/oorb>`_.
 In order to transform some current orbits to a state vector in
 cartesian coordinates, one could use the following code:
 
-.. doctest-requires:: astroquery, oorb
+.. .. doctest-requires:: astroquery, oorb
 .. doctest-remote-data::
 
     >>> elem = Orbit.from_horizons(['Ceres', 'Pallas', 'Vesta'])
@@ -120,7 +120,7 @@ propagated to either as `~astropy.time.Time` object, or as float in
 terms of Julian date. The following example propagates the current
 orbit of Ceres back to year 2000:
 
-.. doctest-requires:: astroquery, oorb
+.. .. doctest-requires:: astroquery, oorb
 .. doctest-remote-data::
 
     >>> elem = Orbit.from_horizons('Ceres')
@@ -148,7 +148,7 @@ parameter with respect to Jupiter is used in the dynamical classification of
 comets.  The Tisserand parameter can be calculated by `~sbpy.Orbit.tisserand`
 as follows:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> epoch = Time(2449400.5, format='jd', scale='tdb')
@@ -162,7 +162,7 @@ One can also specify the planet with respect to which the Tisserand parameter
 is calculated with optional parameter `planet`.  It also allows multiple
 planet to be specified simultaneously:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> import numpy as np
@@ -190,7 +190,7 @@ Drummond function (`Drummond 1991 <https://ui.adsabs.harvard.edu/abs/1981Icar...
 The code example below demonstrates the calculation of three versions of
 D_criterion:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> import numpy as np

--- a/docs/sbpy/data/orbit.rst
+++ b/docs/sbpy/data/orbit.rst
@@ -9,8 +9,9 @@ Orbit Queries
 body osculating elements from the `JPL Horizons service
 <https://ssd.jpl.nasa.gov/horizons/>`_:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
-    
+
     >>> from sbpy.data import Orbit
     >>> from astropy.time import Time
     >>> epoch = Time('2018-05-14', scale='utc')
@@ -30,7 +31,10 @@ scale of the desired epoch is not supported by the query function and
 hence converted to a scale that is supported (``tdb`` in this case).
 The following fields are available in this object:
 
-    >>> elem.field_names  # doctest: +REMOTE_DATA
+.. doctest-requires:: astroquery
+.. doctest-remote-data::
+
+    >>> elem.field_names
     ['targetname', 'H', 'G', 'e', 'q', 'incl', 'Omega', 'w', 'n', 'M', 'nu', 'a', 'Q', 'P', 'epoch', 'Tp']
 
 If ``epochs`` is not set, the osculating elements for the current
@@ -40,6 +44,7 @@ epoch (current time) are queried. Similar to
 parameter on to that function. Furthermore, it is possible to query
 orbital elements for a number of targets:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> epoch = Time('2018-08-03 14:20', scale='tdb')
@@ -59,6 +64,7 @@ Alternatively, orbital elements can also be queried from the `Minor
 Planet Center <https://minorplanetcenter.net/iau/MPEph/MPEph.html>`_,
 although in this case only the most recent elements are accessible:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> elem = Orbit.from_mpc(['3552', '12893'])
@@ -87,6 +93,7 @@ using `OpenOrb <https://github.com/oorb/oorb>`_.
 In order to transform some current orbits to a state vector in
 cartesian coordinates, one could use the following code:
 
+.. doctest-requires:: astroquery, oorb
 .. doctest-remote-data::
 
     >>> elem = Orbit.from_horizons(['Ceres', 'Pallas', 'Vesta'])
@@ -113,6 +120,7 @@ propagated to either as `~astropy.time.Time` object, or as float in
 terms of Julian date. The following example propagates the current
 orbit of Ceres back to year 2000:
 
+.. doctest-requires:: astroquery, oorb
 .. doctest-remote-data::
 
     >>> elem = Orbit.from_horizons('Ceres')
@@ -140,6 +148,7 @@ parameter with respect to Jupiter is used in the dynamical classification of
 comets.  The Tisserand parameter can be calculated by `~sbpy.Orbit.tisserand`
 as follows:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> epoch = Time(2449400.5, format='jd', scale='tdb')
@@ -153,6 +162,7 @@ One can also specify the planet with respect to which the Tisserand parameter
 is calculated with optional parameter `planet`.  It also allows multiple
 planet to be specified simultaneously:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> import numpy as np
@@ -170,6 +180,7 @@ Drummond function (`Drummond 1991 <https://ui.adsabs.harvard.edu/abs/1981Icar...
 The code example below demonstrates the calculation of three versions of
 D_criterion:
 
+.. doctest-requires:: astroquery
 .. doctest-remote-data::
 
     >>> comets = Orbit.from_horizons(['252P', 'P/2016 BA14'],

--- a/docs/sbpy/data/phys.rst
+++ b/docs/sbpy/data/phys.rst
@@ -13,7 +13,7 @@ including the use of `~astropy.units`.
 As an example, the following code will query the properties for a
 small number of asteroids:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from sbpy.data import Phys
@@ -50,7 +50,7 @@ from `~sbpy.data.Phys.from_jplspec` include the following data:
     | Lower level energy in Joules
     | Degrees of freedom
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
     >>> from sbpy.data.phys import Phys

--- a/docs/sbpy/data/phys.rst
+++ b/docs/sbpy/data/phys.rst
@@ -13,8 +13,11 @@ including the use of `~astropy.units`.
 As an example, the following code will query the properties for a
 small number of asteroids:
 
+.. doctest-requires:: astroquery
+.. doctest-remote-data:: 
+
     >>> from sbpy.data import Phys
-    >>> phys = Phys.from_sbdb(['Ceres', '12893', '3552'])  # doctest: +REMOTE_DATA
+    >>> phys = Phys.from_sbdb(['Ceres', '12893', '3552'])
     >>> phys['targetname', 'H', 'diameter'] # doctest: +SKIP
     <QTable length=3>
             targetname            H    diameter
@@ -47,7 +50,8 @@ from `~sbpy.data.Phys.from_jplspec` include the following data:
     | Lower level energy in Joules
     | Degrees of freedom
 
-.. doctest-skip::
+.. doctest-requires:: astroquery
+.. doctest-remote-data:: 
 
     >>> from sbpy.data.phys import Phys
     >>> import astropy.units as u
@@ -55,7 +59,7 @@ from `~sbpy.data.Phys.from_jplspec` include the following data:
     >>> transition_freq = (230.53799 * u.GHz).to('MHz')
     >>> mol_tag = '^CO$'
     >>> mol_data = Phys.from_jplspec(temp_estimate, transition_freq, mol_tag)
-    >>> mol_data
+    >>> mol_data  # doctest: +SKIP
     <QTable length=1>
     Transition frequency Temperature ... Degrees of freedom Molecule Identifier
             MHz               K      ...

--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -134,6 +134,7 @@ initialize a model directly from an `~sbpy.data.Obs` object by fitting the
 data contained therein.
 
 .. doctest-requires:: scipy
+
   >>> # use class method .from_obs
   >>> from astropy.modeling.fitting import SLSQPLSQFitter
   >>> fitter = SLSQPLSQFitter()

--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -60,6 +60,8 @@ management `with` syntax.
 
 Calculate geometric albedo, Bond albedo, and phase integral:
 
+.. doctest-requires:: scipy
+
   >>> import astropy.units as u
   >>> from sbpy.calib import solar_fluxd
   >>> solar_fluxd.set({'V': -26.77 * u.mag})
@@ -112,6 +114,8 @@ parameter of `~astropy.modeling.Model`.  Some fitters, such as
 `astropy.modeling.LevMarLSQFitter`, do not support constrained fit via
 the `ineqcons` parameter, though.
 
+.. doctest-requires:: scipy
+
   >>> import numpy as np
   >>> import astropy.units as u
   >>> from astropy.modeling.fitting import SLSQPLSQFitter
@@ -129,6 +133,7 @@ Alternatively, one may use the class method
 initialize a model directly from an `~sbpy.data.Obs` object by fitting the
 data contained therein.
 
+.. doctest-requires:: scipy
   >>> # use class method .from_obs
   >>> from astropy.modeling.fitting import SLSQPLSQFitter
   >>> fitter = SLSQPLSQFitter()
@@ -140,6 +145,8 @@ One can also initialize a model set from multiple columns in the input
 `~sbpy.data.Obs` object if it contains more than one columns of brightness
 measurements.  The columns to be fitted are specified by a keyward argument
 ``fields``.  By default, the column ``'mag'`` will be fitted.
+
+.. doctest-requires:: scipy
 
   >>> # Initialize model set
   >>> model4 = HG(5.2 * u.mag, 0.18)
@@ -153,6 +160,8 @@ measurements.  The columns to be fitted are specified by a keyward argument
 Filter Bandpasses
 -----------------
 A few filter bandpasses are included with `sbpy` for internal tests and your convenience.  The function `~sbpy.photometry.bandpass` will return the filter transmission as a `~synphot.spectrum.SpectralElement` (requires `synphot`):
+
+.. doctest-requires:: synphot
 
   >>> from sbpy.photometry import bandpass
   >>> bp = bandpass('Cousins R')

--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -83,7 +83,7 @@ The model class can also be initialized by a subclass of ``sbpy``'s
 `~sbpy.data.DataClass`, such as `~sbpy.data.Phys`, as long as it contains the
 model parameters:
 
-.. doctest-requires:: astroquery
+.. .. doctest-requires:: astroquery
 .. doctest-remote-data:: 
 
   >>> from sbpy.data import Phys

--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -83,9 +83,12 @@ The model class can also be initialized by a subclass of ``sbpy``'s
 `~sbpy.data.DataClass`, such as `~sbpy.data.Phys`, as long as it contains the
 model parameters:
 
+.. doctest-requires:: astroquery
+.. doctest-remote-data:: 
+
   >>> from sbpy.data import Phys
-  >>> phys = Phys.from_sbdb('Ceres')    # doctest: +REMOTE_DATA
-  >>> m = HG.from_phys(phys)            # doctest: +REMOTE_DATA
+  >>> phys = Phys.from_sbdb('Ceres')
+  >>> m = HG.from_phys(phys)
   INFO: Model initialized for 1 Ceres (A801 AA). [sbpy.photometry.core]
   >>> print(m)                          # doctest: +SKIP
   Model: HG

--- a/docs/sbpy/photometry.rst
+++ b/docs/sbpy/photometry.rst
@@ -161,6 +161,8 @@ A few filter bandpasses are included with `sbpy` for internal tests and your con
 
 For other bandpasses, obtain the photon-counting relative spectral response curves as a two-column file.  If the first column is wavelength in Angstroms, and the second is the response, then read the file with:
 
+.. doctest-requires:: synphot
+
   >>> from synphot import SpectralElement             # doctest: +SKIP
   >>> bp = SpectralElement.from_file('filename.txt')  # doctest: +SKIP
 

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -47,7 +47,7 @@ inverse length.  For convenience, `sbpy` includes a
 
 Initialize a spectral gradient from a color index:
 
-.. doctest-requires:: astropy>=5.3
+.. doctest-requires:: astropy>=5.3, synphot
 
   >>> w = (550, 650) * u.nm
   >>> SpectralGradient.from_color(w, 0.1 * u.mag)  # doctest: +FLOAT_CMP
@@ -57,6 +57,8 @@ Note we use the dimensionless magnitude unit from `astropy`, i.e., not
 one that carries flux density units such as `astropy.units.ABmag`.
 
 Convert spectral gradient (normalized to 550 nm) to a color index:
+
+.. doctest-requires:: synphot
 
   >>> S = SpectralGradient(10 * u.percent / hundred_nm, wave0=550 * u.nm)
   >>> S.to_color((500, 600) * u.nm)  # doctest: +FLOAT_CMP

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -29,6 +29,8 @@ re-normalization to other wavelengths.
 inverse length.  For convenience, `sbpy` includes a
 `~sbpy.units.hundred_nm` unit, which is equal to 100 nm:
 
+.. These imports are needed for astropy versions < 5.3 because the next
+   doctest block only executes for versions >=5.3.
 .. testsetup::
 .. doctest-requires:: astropy<5.3
 

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -74,7 +74,7 @@ Renormalize to 1.0 μm:
 Spectral Reddening
 ------------------
 
-Linear spectral reddening is enabled by class `~sbpy.spectroscopy.Reddening`,
+Linear spectral reddening is enabled by the class `~sbpy.spectroscopy.Reddening`,
 which is based on `~synphot.spectrum.BaseUnitlessSpectrum`.
 
 Initialize a `~sbpy.spectroscopy.Reddening` class from a spectral gradient:

--- a/docs/sbpy/units.rst
+++ b/docs/sbpy/units.rst
@@ -60,6 +60,8 @@ Unit conversions between flux density and Vega-based magnitudes use the `astropy
 
 To use a bandpass, define and pass a `synphot.spectrum.SpectralElement`.  A limited set of bandpasses are distributed with sbpy (see :ref:`filter-bandpasses`):
 
+.. doctest-requires:: synphot
+
   >>> from sbpy.units import VEGAmag, spectral_density_vega
   >>> from sbpy.photometry import bandpass
   >>> V = bandpass('Johnson V')

--- a/docs/sbpy/units.rst
+++ b/docs/sbpy/units.rst
@@ -9,8 +9,10 @@ Introduction
   >>> import sbpy.units
   >>> sbpy.units.enable()    # doctest: +IGNORE_OUTPUT
 
-This will make them searchable via strings, such as
-``u.Unit('mag(VEGA)')``.
+This will make them searchable via strings, such as:
+
+  >> print(u.Unit("mag(VEGA)"))
+  VEGAmag
 
 
 Spectral Gradient Units
@@ -42,6 +44,8 @@ With the synphot package, sbpy has the capability to convert between flux densit
 sbpy defines two new spectral flux density units: ``VEGA`` and ``JM``.  ``VEGA`` represents the flux density of Vega.  ``JM`` represents the flux density zeropoint of the Johnson-Morgan system, assuming Vega has a magnitude of 0.03 at all wavelengths (`Johnson et al. 1966 <https://ui.adsabs.harvard.edu/abs/1966CoLPL...4...99J>`_, `Bessell & Murphy 2012 <https://ui.adsabs.harvard.edu/abs/2012PASP..124..140B>`_).  Two magnitude units are also defined: ``VEGAmag`` and ``JMmag``.
 
 Unit conversions between flux density and Vega-based magnitudes use the `astropy.units equivalency system <https://docs.astropy.org/en/stable/units/equivalencies.html#unit-equivalencies>`_.  sbpy's :func:`~sbpy.units.spectral_density_vega` provides the equivalencies, which astropy would use to convert the units.  The function requires a wavelength, frequency, or bandpass:
+
+.. doctest-requires:: synphot
 
   >>> import astropy.units as u
   >>> from sbpy.units import VEGAmag, spectral_density_vega
@@ -111,6 +115,8 @@ phase angle can be calculated:
   >>> cross_sec = np.pi * (radius)**2
   >>> ref = mag.to('1/sr', reflectance('V', cross_section=cross_sec))
 
+.. doctest-requires:: synphot
+
   >>> from sbpy.photometry import bandpass
   >>> V = bandpass('Johnson V')
   >>> ref = 0.0287 / u.sr
@@ -120,6 +126,8 @@ phase angle can be calculated:
   459.69 km
 
 `~sbpy.units.reflectance` also supports conversion between a flux spectrum and a reflectance spectrum:
+
+.. doctest-requires:: synphot
 
   >>> wave = [1.046, 1.179, 1.384, 1.739, 2.416] * u.um
   >>> flux = [1.636e-18, 1.157e-18, 8.523e-19, 5.262e-19, 1.9645e-19] \

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -15,22 +15,20 @@ __doctest_requires__ = {
     "Efrho.to_fluxd": ["synphot"],
 }
 
-from warnings import warn
 import abc
 
 import numpy as np
 import astropy.units as u
 
 try:
-    import scipy
     from scipy.interpolate import splrep, splev
 except ImportError:
-    scipy = None
+    pass
 
 from .. import bib
 from ..calib import Sun
 from ..spectroscopy import BlackbodySource
-from ..utils import optional
+from ..utils import optional_packages
 from .. import data as sbd
 from .. import units as sbu
 from ..spectroscopy.sources import SinglePointSpectrumError
@@ -289,7 +287,7 @@ def phase_HalleyMarcus(phase):
 
     _phase = np.abs(u.Quantity(phase, "deg").value)
 
-    if optional("scipy"):
+    if optional_packages("scipy"):
         Phi = splev(_phase, splrep(th, ph))
     else:
         Phi = np.interp(_phase, th, ph)

--- a/sbpy/activity/gas/core.py
+++ b/sbpy/activity/gas/core.py
@@ -88,7 +88,8 @@ def photo_lengthscale(species, source=None):
         for k, v in sorted(data.items()):
             summary += "\n{} [{}]".format(k, ", ".join(v.keys()))
 
-        raise ValueError("Invalid species {}.  Choose from:{}".format(species, summary))
+        raise ValueError(
+            "Invalid species {}.  Choose from:{}".format(species, summary))
 
     gas = data[species]
     source = default_sources[species] if source is None else source
@@ -163,7 +164,8 @@ def photo_timescale(species, source=None):
         for k, v in sorted(data.items()):
             summary += "\n{} [{}]".format(k, ", ".join(v.keys()))
 
-        raise ValueError("Invalid species {}.  Choose from:{}".format(species, summary))
+        raise ValueError(
+            "Invalid species {}.  Choose from:{}".format(species, summary))
 
     gas = data[species]
     source = default_sources[species] if source is None else source
@@ -1275,11 +1277,13 @@ class VectorialModel(GasComa):
         # occupy)
         # NOTE: Equation (16) of Festou 1981 where alpha is the percent
         # destruction of molecules
-        parent_beta_r = -np.log(1.0 - self.model_params.parent_destruction_level)
+        parent_beta_r = - \
+            np.log(1.0 - self.model_params.parent_destruction_level)
         parent_r = parent_beta_r * vp * self.parent.tau_T
         self.vmr.coma_radius = parent_r * u.m
 
-        fragment_beta_r = -np.log(1.0 - self.model_params.fragment_destruction_level)
+        fragment_beta_r = - \
+            np.log(1.0 - self.model_params.fragment_destruction_level)
         # Calculate the time needed to hit a steady, permanent production of
         # fragments
         perm_flow_radius = self.vmr.coma_radius.value + (
@@ -1508,7 +1512,8 @@ class VectorialModel(GasComa):
 
                 # differential addition to the density integrating along dr,
                 # similar to eq. (36) Festou 1981
-                n_r = (p_extinction * f_extinction * q_r_eps) / (sep_dist**2 * v)
+                n_r = (p_extinction * f_extinction *
+                       q_r_eps) / (sep_dist**2 * v)
 
                 sputter += n_r * dr
 
@@ -1564,7 +1569,8 @@ class VectorialModel(GasComa):
         # Equivalent to summing over j for sin(theta[j]) *
         # fragment_sputter[i][j] with numpy magic
         self.solid_angle_sputter = np.sin(thetas) * self.fragment_sputter
-        self.fast_voldens = 2.0 * np.pi * np.sum(self.solid_angle_sputter, axis=1)
+        self.fast_voldens = 2.0 * np.pi * \
+            np.sum(self.solid_angle_sputter, axis=1)
 
         # Tag with proper units
         self.vmr.volume_density = self.fast_voldens / (u.m**3)
@@ -1629,7 +1635,8 @@ class VectorialModel(GasComa):
         def column_density_integrand(z):
             return self._volume_density(np.sqrt(z**2 + rhosq))
 
-        c_dens = 2 * romberg(column_density_integrand, 0, z_max, rtol=0.0001, divmax=50)
+        c_dens = 2 * romberg(column_density_integrand, 0,
+                             z_max, rtol=0.0001, divmax=50)
 
         # result is in 1/m^2
         return c_dens
@@ -1704,7 +1711,8 @@ class VectorialModel(GasComa):
         for i, t in enumerate(time_slices[:-1]):
             extinction_one = t / p_tau_T
             extinction_two = time_slices[i + 1] / p_tau_T
-            mult_factor = -np.e ** (-extinction_one) + np.e ** (-extinction_two)
+            mult_factor = -np.e ** (-extinction_one) + \
+                np.e ** (-extinction_two)
             theory_total += self.production_at_time(t) * mult_factor
 
         return theory_total * alpha - edge_adjust

--- a/sbpy/activity/gas/data/__init__.py
+++ b/sbpy/activity/gas/data/__init__.py
@@ -16,7 +16,7 @@ from astropy.utils.data import get_pkg_data_path
 
 from .... import data as sbd
 from .... import bib
-from ....utils import optional
+from ....utils import optional_packages
 
 photo_lengthscale = {   # (value, {key feature: ADS bibcode})
     'H2O': {
@@ -122,7 +122,7 @@ class OHFluorescenceSA88:
         self._LN = u.Quantity(self.table5[k].data * self.scales[i],
                               'erg / s')
 
-        if optional("scipy"):
+        if optional_packages("scipy"):
             from scipy.interpolate import splrep
             self._tck = splrep(self.rdot.value, self.LN.value)
             self._interp = self._spline

--- a/sbpy/activity/gas/data/__init__.py
+++ b/sbpy/activity/gas/data/__init__.py
@@ -8,22 +8,15 @@ __all__ = [
     'OHFluorescenceSA88'
 ]
 
-from warnings import warn
-
 import numpy as np
-try:
-    import scipy
-    from scipy import interpolate
-except ImportError:
-    scipy = None
 
 import astropy.units as u
 from astropy.io import ascii
-from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.data import get_pkg_data_path
 
 from .... import data as sbd
-from .... import exceptions as sbe
 from .... import bib
+from ....utils import optional
 
 photo_lengthscale = {   # (value, {key feature: ADS bibcode})
     'H2O': {
@@ -113,7 +106,7 @@ class OHFluorescenceSA88:
              '0-1', '0-2', '1-2', '2-0', '2-1']
 
     def __init__(self, band):
-        fn = get_pkg_data_filename('schleicher88.txt')
+        fn = get_pkg_data_path('schleicher88.txt')
         self.table5 = ascii.read(fn)
         self._rdot = self.table5['rdot'].data * u.km / u.s
         self._inversion = self.table5['I']
@@ -129,16 +122,16 @@ class OHFluorescenceSA88:
         self._LN = u.Quantity(self.table5[k].data * self.scales[i],
                               'erg / s')
 
-        if scipy:
-            self._tck = interpolate.splrep(self.rdot.value, self.LN.value)
+        if optional("scipy"):
+            from scipy.interpolate import splrep
+            self._tck = splrep(self.rdot.value, self.LN.value)
             self._interp = self._spline
         else:
-            warn(sbe.OptionalPackageUnavailable(
-                'scipy unavailable, using linear interpolation.'))
             self._interp = self._linear
 
     def _spline(self, rdot, rh):
-        return interpolate.splev(rdot, self._tck, ext=2) / rh**2
+        from scipy.interpolate import splev
+        return splev(rdot, self._tck, ext=2) / rh**2
 
     def _linear(self, rdot, rh):
         return np.interp(rdot, self.rdot.value, self.LN.value) / rh**2

--- a/sbpy/activity/gas/productionrate.py
+++ b/sbpy/activity/gas/productionrate.py
@@ -30,6 +30,7 @@ from ...bib import register
 from ...data import Phys
 from ...exceptions import RequiredPackageUnavailable
 from ...utils.decorators import requires
+from ...utils import required_packages
 
 __all__ = ['LTE', 'NonLTE', 'einstein_coeff',
            'intensity_conversion', 'beta_factor', 'total_number',
@@ -257,8 +258,8 @@ def beta_factor(mol_data, ephemobj):
     r = (orb['r'])
 
     if not isinstance(mol_data['mol_tag'][0], str):
-        if astroquery is None:
-            raise RequiredPackageUnavailable(f"mol_tag = {mol_data['mol_tag'][0]} requires astroquery")
+        required_packages(
+            "astroquery", f"mol_tag = {mol_data['mol_tag'][0]} requires astroquery")
 
         cat = JPLSpec.get_species_table()
         mol = cat[cat['TAG'] == mol_data['mol_tag'][0]]
@@ -664,7 +665,7 @@ class NonLTE():
     """
 
     @staticmethod
-    @requires(pyradex, astroquery)
+    @requires("pyradex", "astroquery")
     def from_pyradex(integrated_flux, mol_data, line_width=1.0 * u.km / u.s,
                      escapeProbGeom='lvg', iter=100,
                      collider_density={'H2': 900*2.2}):

--- a/sbpy/activity/gas/productionrate.py
+++ b/sbpy/activity/gas/productionrate.py
@@ -15,11 +15,10 @@ import astropy.constants as con
 import astropy.units as u
 
 try:
-    import astroquery
     from astroquery.jplspec import JPLSpec
     from astroquery.lamda import Lamda
 except ImportError:
-    astroquery = None
+    pass
 
 try:
     import pyradex
@@ -28,7 +27,6 @@ except ImportError:
 
 from ...bib import register
 from ...data import Phys
-from ...exceptions import RequiredPackageUnavailable
 from ...utils.decorators import requires
 from ...utils import required_packages
 
@@ -259,7 +257,7 @@ def beta_factor(mol_data, ephemobj):
 
     if not isinstance(mol_data['mol_tag'][0], str):
         required_packages(
-            "astroquery", f"mol_tag = {mol_data['mol_tag'][0]} requires astroquery")
+            "astroquery", message=f"mol_tag = {mol_data['mol_tag'][0]} requires astroquery")
 
         cat = JPLSpec.get_species_table()
         mol = cat[cat['TAG'] == mol_data['mol_tag'][0]]

--- a/sbpy/activity/gas/tests/test_core.py
+++ b/sbpy/activity/gas/tests/test_core.py
@@ -18,6 +18,7 @@ from .. import (
 )
 from ....data import Phys
 
+
 def test_photo_lengthscale():
     gamma = photo_lengthscale("OH", "CS93")
     assert gamma == 1.6e5 * u.km
@@ -99,7 +100,7 @@ class TestHaser:
         Should be within 1% of ideal value.
 
         """
-        
+
         pytest.importorskip("scipy")
 
         Q = 1e28 / u.s
@@ -117,7 +118,7 @@ class TestHaser:
         Test column density for aperture = lengthscale.
 
         """
-        
+
         pytest.importorskip("scipy")
 
         Q = 1e28 / u.s
@@ -131,9 +132,9 @@ class TestHaser:
 
     def test_total_number_large_aperture(self):
         """Test column density for aperture >> lengthscale."""
-        
+
         pytest.importorskip("scipy")
-        
+
         Q = 1 / u.s
         v = 1 * u.km / u.s
         rho = 1000 * u.km
@@ -150,7 +151,7 @@ class TestHaser:
         Code initially from Quanzhi Ye.
 
         """
-        
+
         pytest.importorskip("scipy")
 
         Q = 1e25 / u.s
@@ -249,7 +250,7 @@ class TestHaser:
         parent only
 
         """
-        
+
         pytest.importorskip("scipy")
 
         # Nobs = 2.314348613550494e+27
@@ -286,7 +287,7 @@ class TestHaser:
 
     def test_total_number_annulus(self):
         """Test column density for annular aperture."""
-    
+
         pytest.importorskip("scipy")
 
         Q = 1 / u.s
@@ -355,7 +356,7 @@ class TestHaser:
         which is within 0.5% of the test value below
 
         """
-    
+
         pytest.importorskip("scipy")
 
         parent = 1.4e4 * u.km

--- a/sbpy/activity/gas/tests/test_core.py
+++ b/sbpy/activity/gas/tests/test_core.py
@@ -369,7 +369,7 @@ class TestHaser:
         assert np.isclose(N, 5.146824269306973e27, rtol=0.005)
 
 
-@pytest.mark.skipif("scipy is None")
+@pytest.mark.skipif(scipy is None)
 class TestVectorialModel:
     def test_small_vphoto(self):
         """

--- a/sbpy/activity/gas/tests/test_core.py
+++ b/sbpy/activity/gas/tests/test_core.py
@@ -90,7 +90,8 @@ class TestHaser:
         parent = 1e4 * u.km
         N_avg = 2 * Haser(Q, v, parent).column_density(rho)
         ideal = Q / v / 2 / rho
-        assert np.isclose(N_avg.decompose().value, ideal.decompose().value, rtol=0.001)
+        assert np.isclose(N_avg.decompose().value,
+                          ideal.decompose().value, rtol=0.001)
 
     def test_column_density_small_angular_aperture(self):
         """Test column density for angular aperture << lengthscale.
@@ -109,9 +110,11 @@ class TestHaser:
         eph = dict(delta=1 * u.au)
         parent = 1e4 * u.km
         N_avg = 2 * Haser(Q, v, parent).column_density(rho, eph)
-        rho_km = (rho * eph["delta"] * 725.24 * u.km / u.arcsec / u.au).to("km")
+        rho_km = (rho * eph["delta"] * 725.24 *
+                  u.km / u.arcsec / u.au).to("km")
         ideal = Q / v / 2 / rho_km
-        assert np.isclose(N_avg.to_value("1/m2"), ideal.to_value("1/m2"), rtol=0.001)
+        assert np.isclose(N_avg.to_value("1/m2"),
+                          ideal.to_value("1/m2"), rtol=0.001)
 
     def test_column_density(self):
         """
@@ -296,8 +299,10 @@ class TestHaser:
         parent = 10 * u.km
         N = Haser(Q, v, parent).total_number(aper)
 
-        N1 = Haser(Q, v, parent).total_number(core.CircularAperture(aper.dim[0]))
-        N2 = Haser(Q, v, parent).total_number(core.CircularAperture(aper.dim[1]))
+        N1 = Haser(Q, v, parent).total_number(
+            core.CircularAperture(aper.dim[0]))
+        N2 = Haser(Q, v, parent).total_number(
+            core.CircularAperture(aper.dim[1]))
 
         assert np.allclose(N, N2 - N1)
 
@@ -369,7 +374,7 @@ class TestHaser:
         assert np.isclose(N, 5.146824269306973e27, rtol=0.005)
 
 
-@pytest.mark.skipif(scipy is None)
+@pytest.mark.skipif(scipy is None, reason="requires scipy")
 class TestVectorialModel:
     def test_small_vphoto(self):
         """
@@ -396,7 +401,8 @@ class TestVectorialModel:
         # Fragment molecule is OH, but v_photo is modified to be smaller than
         # v_outflow
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 0.5 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 0.5 * u.km / u.s}
         )
 
         coma = VectorialModel(
@@ -433,7 +439,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         coma_steady = VectorialModel(
@@ -477,7 +484,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         coma_binned = VectorialModel.binned_production(
@@ -516,7 +524,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         coma_binned = VectorialModel.binned_production(
@@ -552,7 +561,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         coma = VectorialModel(base_q=base_q, parent=parent, fragment=fragment)
@@ -580,7 +590,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         coma = VectorialModel(base_q=base_q, parent=parent, fragment=fragment)
@@ -625,7 +636,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": photo_timescale("OH") * 0.93, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": photo_timescale("OH") * 0.93,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         coma = VectorialModel(
@@ -703,7 +715,8 @@ class TestVectorialModel:
         )
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": 160000 * (rh / u.au) ** 2 * u.s, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": 160000 * (rh / u.au) ** 2 * u.s,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         # https://pds.nasa.gov/ds-view/pds/viewInstrumentProfile.jsp?INSTRUMENT_ID=LWP&INSTRUMENT_HOST_ID=IUE
@@ -770,7 +783,8 @@ class TestVectorialModel:
 
         # Fragment molecule is OH
         fragment = Phys.from_dict(
-            {"tau_T": 2.0e5 * (rh / u.au) ** 2 * u.s, "v_photo": 1.05 * u.km / u.s}
+            {"tau_T": 2.0e5 * (rh / u.au) ** 2 * u.s,
+             "v_photo": 1.05 * u.km / u.s}
         )
 
         Q0 = 2e29 / u.s
@@ -910,7 +924,8 @@ class TestVectorialModel:
         sigma0_rho = x[::2] * u.km
         sigma0 = x[1::2] / u.cm**2
         # absolute tolerance: 3 significant figures
-        sigma0_atol = 1.1 * 10 ** (np.floor(np.log10(sigma0.value)) - 2) * sigma0.unit
+        sigma0_atol = 1.1 * \
+            10 ** (np.floor(np.log10(sigma0.value)) - 2) * sigma0.unit
         sigma0_atol_revised = sigma0_atol * 40
 
         # evaluate the model

--- a/sbpy/activity/gas/tests/test_data.py
+++ b/sbpy/activity/gas/tests/test_data.py
@@ -1,14 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import importlib
 import pytest
 import numpy as np
 import astropy.units as u
 from .. import data
 
+def patched_import_module(name):
+    if name == "scipy":
+        raise ModuleNotFoundError
+    __import__(name)
 
 class TestOHFluorescenceSA88:
     def test_linear_interpolation(self, monkeypatch):
-        monkeypatch.setattr(data, 'scipy', None)
+        monkeypatch.setattr(importlib, "import_module", patched_import_module)
         model = data.OHFluorescenceSA88('0-0')
         LN = model(-1 * u.km / u.s)
         assert np.isclose(LN.value, 1.54e-15)

--- a/sbpy/activity/gas/tests/test_data.py
+++ b/sbpy/activity/gas/tests/test_data.py
@@ -6,32 +6,34 @@ import numpy as np
 import astropy.units as u
 from .. import data
 
+
 def patched_import_module(name):
     if name == "scipy":
         raise ModuleNotFoundError
     __import__(name)
 
+
 class TestOHFluorescenceSA88:
     def test_linear_interpolation(self, monkeypatch):
         monkeypatch.setattr(importlib, "import_module", patched_import_module)
-        model = data.OHFluorescenceSA88('0-0')
+        model = data.OHFluorescenceSA88("0-0")
         LN = model(-1 * u.km / u.s)
         assert np.isclose(LN.value, 1.54e-15)
 
     def test_tau(self):
-        model = data.OHFluorescenceSA88('0-0')
+        model = data.OHFluorescenceSA88("0-0")
         assert np.isclose(model.tau[0].value, 2.87e5)
 
     def test_inversion(self):
-        model = data.OHFluorescenceSA88('0-0')
+        model = data.OHFluorescenceSA88("0-0")
         assert np.isclose(model.inversion[0], -0.304)
 
     def test_rdot_error(self):
-        model = data.OHFluorescenceSA88('0-0')
+        model = data.OHFluorescenceSA88("0-0")
         with pytest.raises(ValueError):
             model(-61 * u.km / u.s)
 
     def test_rh_error(self):
-        model = data.OHFluorescenceSA88('0-0')
+        model = data.OHFluorescenceSA88("0-0")
         with pytest.raises(ValueError):
-            model({'rdot': 1 * u.km / u.s, 'rh': 0.4 * u.au})
+            model({"rdot": 1 * u.km / u.s, "rh": 0.4 * u.au})

--- a/sbpy/activity/gas/tests/test_data.py
+++ b/sbpy/activity/gas/tests/test_data.py
@@ -1,24 +1,24 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import importlib
+from unittest.mock import patch
 import pytest
 import numpy as np
 import astropy.units as u
 from .. import data
 
 
-def patched_import_module(name):
-    if name == "scipy":
-        raise ModuleNotFoundError
-    __import__(name)
-
-
 class TestOHFluorescenceSA88:
-    def test_linear_interpolation(self, monkeypatch):
-        monkeypatch.setattr(importlib, "import_module", patched_import_module)
+    def test_spline_interpolation(self):
+        pytest.importorskip("scipy")
         model = data.OHFluorescenceSA88("0-0")
-        LN = model(-1 * u.km / u.s)
-        assert np.isclose(LN.value, 1.54e-15)
+        LN = model(-0.5 * u.km / u.s)
+        assert np.isclose(LN.value, 1.50307895e-15)
+
+    @patch.dict("sys.modules", {"scipy": None})
+    def test_linear_interpolation(self, monkeypatch):
+        model = data.OHFluorescenceSA88("0-0")
+        LN = model(-0.5 * u.km / u.s)
+        assert np.isclose(LN.value, 1.515e-15)
 
     def test_tau(self):
         model = data.OHFluorescenceSA88("0-0")

--- a/sbpy/activity/gas/tests/test_prodrate.py
+++ b/sbpy/activity/gas/tests/test_prodrate.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pytest
 import numpy as np
 import astropy.units as u
 from .. import Haser, photo_timescale
@@ -85,6 +86,8 @@ class TestProductionRate:
 
     def test_Haser_prodrate(self):
         """Test a set of dummy values."""
+
+        pytest.importorskip("scipy")
 
         temp_estimate = 47. * u.K
         vgas = 0.8 * u.km / u.s

--- a/sbpy/activity/gas/tests/test_prodrate_remote.py
+++ b/sbpy/activity/gas/tests/test_prodrate_remote.py
@@ -6,19 +6,12 @@ import numpy as np
 import astropy.units as u
 from astropy.time import Time
 from astropy.table import Table
-from astroquery.lamda import Lamda
-from astroquery.jplspec import JPLSpec
-import pytest
 
-try:
-    import pyradex
-except ImportError:
-    pyradex = None
+import pytest
 
 from .. import (Haser, photo_timescale, LTE, NonLTE, einstein_coeff,
                 intensity_conversion, beta_factor, total_number, from_Haser)
 from ....data import Ephem, Phys
-
 
 class MockPyradex:
     """
@@ -268,9 +261,9 @@ See https://github.com/keflavich/pyradex for installment
 '''
 
 
-@pytest.mark.skipif('pyradex is None')
 @pytest.mark.remote_data
 def test_Haser_pyradex():
+    pytest.importorskip("pyradex")
     pytest.importorskip("astroquery", minversion="0.4.7")
 
     co = Table.read(data_path('CO.csv'), format="ascii.csv")
@@ -387,9 +380,9 @@ See https://github.com/keflavich/pyradex for installment
 '''
 
 
-@pytest.mark.skipif('pyradex is None')
 @pytest.mark.remote_data
 def test_pyradex_case():
+    pytest.importorskip("pyradex")
     pytest.importorskip("astroquery", minversion="0.4.7")
 
     transition_freq = (177.196 * u.GHz).to(u.MHz)
@@ -410,9 +403,9 @@ def test_pyradex_case():
     assert np.isclose(cdensity.value[0], 1.134e14)
 
 
-@pytest.mark.skipif('pyradex is None')
 @pytest.mark.remote_data
 def test_Haser_prodrate_pyradex(mock_nonlte):
+    pytest.importorskip("pyradex")
     pytest.importorskip("astroquery", minversion="0.4.7")
 
     co = Table.read(data_path('CO.csv'), format="ascii.csv")

--- a/sbpy/activity/gas/tests/test_prodrate_remote.py
+++ b/sbpy/activity/gas/tests/test_prodrate_remote.py
@@ -13,6 +13,7 @@ from .. import (Haser, photo_timescale, LTE, NonLTE, einstein_coeff,
                 intensity_conversion, beta_factor, total_number, from_Haser)
 from ....data import Ephem, Phys
 
+
 class MockPyradex:
     """
     Class to be the mock return value of NonLTE.from_pyradex

--- a/sbpy/activity/tests/test_dust.py
+++ b/sbpy/activity/tests/test_dust.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
-import mock
+from unittest import mock
 import pytest
 import numpy as np
 import astropy.units as u
-import synphot
+
 from ..dust import *
 from ..core import CircularAperture
 from ...calib import solar_fluxd
@@ -18,6 +18,7 @@ Wm2um = u.W / u.m**2 / u.um
 
 
 def box(center, width):
+    synphot = pytest.importorskip("synphot")
     return synphot.SpectralElement(
         synphot.Box1D, x_0=center * u.um, width=width * u.um)
 
@@ -36,9 +37,9 @@ def test_phase_HalleyMarcus(phase, value):
     (15, 5.8720e-01),
     (14.5, (6.0490e-01 + 5.8720e-01) / 2)
 ))
+@mock.patch.dict(sys.modules, {'scipy': None})
 def test_phase_HalleyMarcus_linear_interp(phase, value):
-    with mock.patch.dict(sys.modules, {'scipy': None}):
-        assert np.isclose(phase_HalleyMarcus(phase * u.deg), value)
+    assert np.isclose(phase_HalleyMarcus(phase * u.deg), value)
 
 
 class TestAfrho:
@@ -102,6 +103,9 @@ class TestAfrho:
             synphot.units.convert_flux(6182, 11.97 * u.ABmag, u.STmag)
 
         """
+    
+        pytest.importorskip("synphot")
+
         eph = Ephem.from_dict(dict(rh=rh * u.au, delta=delta * u.au))
 
         cal = {}
@@ -249,6 +253,9 @@ class TestEfrho:
           * Added a significant figure to Encke εfρ: 31 → 31.1.
 
         """
+
+        pytest.importorskip("synphot")
+
         eph = dict(rh=rh * u.au, delta=delta * u.au)
         efrho = (Efrho.from_fluxd(wfb, fluxd0, rho, eph, Tscale=1.1, B=B, T=T)
                  .to('cm'))

--- a/sbpy/activity/tests/test_dust.py
+++ b/sbpy/activity/tests/test_dust.py
@@ -103,7 +103,7 @@ class TestAfrho:
             synphot.units.convert_flux(6182, 11.97 * u.ABmag, u.STmag)
 
         """
-    
+
         pytest.importorskip("synphot")
 
         eph = Ephem.from_dict(dict(rh=rh * u.au, delta=delta * u.au))

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -34,7 +34,7 @@ except ImportError:
 
 from astropy import log
 
-from ..exceptions import RequiredPackageUnavailable
+from ..utils.decorators import requires
 
 
 def register(task, citations):
@@ -228,6 +228,7 @@ def show(filter=None):
     return output
 
 
+@requires("ads")
 def to_text(filter=None):
     """Convert bibcodes to human readable text.
 
@@ -246,9 +247,6 @@ def to_text(filter=None):
         the bibcodes.
 
     """
-
-    if ads is None:
-        raise RequiredPackageUnavailable("requires ads")
 
     output = ''
     for task, ref in _filter(filter).items():
@@ -316,6 +314,7 @@ def to_text(filter=None):
     return output
 
 
+@requires("ads")
 def _to_format(format, filter=None):
     """Convert bibcodes to a range of different output formats.
 
@@ -338,9 +337,6 @@ def _to_format(format, filter=None):
         for each reference.
 
     """
-
-    if ads is None:
-        raise RequiredPackageUnavailable("requires ads")
 
     output = ''
     for task, ref in _filter(filter).items():

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -22,6 +22,10 @@ __all__ = [
     'to_mnras'
 ]
 
+__doctest_requires__ = {
+    "cite": ["ads"],
+}
+
 import warnings
 from functools import wraps
 from collections import OrderedDict, defaultdict

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -26,7 +26,15 @@ import warnings
 from functools import wraps
 from collections import OrderedDict, defaultdict
 import atexit
+
+try:
+    import ads
+except ImportError:
+    ads = None
+
 from astropy import log
+
+from ..exceptions import RequiredPackageUnavailable
 
 
 def register(task, citations):
@@ -238,7 +246,9 @@ def to_text(filter=None):
         the bibcodes.
 
     """
-    import ads
+
+    if ads is None:
+        raise RequiredPackageUnavailable("requires ads")
 
     output = ''
     for task, ref in _filter(filter).items():
@@ -328,7 +338,9 @@ def _to_format(format, filter=None):
         for each reference.
 
     """
-    import ads
+
+    if ads is None:
+        raise RequiredPackageUnavailable("requires ads")
 
     output = ''
     for task, ref in _filter(filter).items():

--- a/sbpy/calib/core.py
+++ b/sbpy/calib/core.py
@@ -37,7 +37,7 @@ from ..exceptions import SbpyException
 from .. import bib
 from . import solar_sources, vega_sources
 from ..utils.decorators import requires
-from ..utils import optional
+from ..utils import optional_packages
 
 try:
     import synphot
@@ -136,7 +136,7 @@ class SpectralStandard(SpectralSource, ABC):
         The spectrum will be ``None`` if `synphot` is not available.
 
         """
-        if optional("synphot"):
+        if optional_packages("synphot"):
             standard = cls._spectrum_state.get()
         else:
             standard = cls(None)

--- a/sbpy/calib/core.py
+++ b/sbpy/calib/core.py
@@ -43,6 +43,7 @@ try:
     from synphot import SpectralElement
 except ImportError:
     synphot = None
+
     class SpectralElement:
         pass
 

--- a/sbpy/calib/core.py
+++ b/sbpy/calib/core.py
@@ -36,7 +36,8 @@ from ..spectroscopy.sources import SpectralSource
 from ..exceptions import SbpyException
 from .. import bib
 from . import solar_sources, vega_sources
-from ..utils.decorators import optional, requires
+from ..utils.decorators import requires
+from ..utils import optional
 
 try:
     import synphot
@@ -129,17 +130,16 @@ class SpectralStandard(SpectralSource, ABC):
         return cls.from_file(**parameters)
 
     @classmethod
-    @optional("synphot")
     def from_default(cls):
         """Initialize new spectral standard from current default.
 
         The spectrum will be ``None`` if `synphot` is not available.
 
         """
-        if synphot is None:
-            standard = cls(None)
-        else:
+        if optional("synphot"):
             standard = cls._spectrum_state.get()
+        else:
+            standard = cls(None)
         return standard
 
     @classmethod

--- a/sbpy/calib/tests/test_core.py
+++ b/sbpy/calib/tests/test_core.py
@@ -18,8 +18,8 @@ class Star(SpectralStandard):
 class TestSpectralStandard:
     def test_from_array(self):
         pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
         s = Star.from_array(w, f)
         assert np.allclose(f.value, s(w, f.unit).value)
 
@@ -27,33 +27,36 @@ class TestSpectralStandard:
 
     def test_description(self):
         pytest.importorskip("synphot")
-        s = Star(None, description='asdf')
-        assert s.description == 'asdf'
+        s = Star(None, description="asdf")
+        assert s.description == "asdf"
 
     def test_wave(self):
         synphot = pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
-        source = synphot.SourceSpectrum(synphot.Empirical1D, points=w,
-                                        lookup_table=f)
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
+        source = synphot.SourceSpectrum(
+            synphot.Empirical1D, points=w, lookup_table=f
+        )
         s = Star(source)
         assert np.allclose(s.wave.to(w.unit).value, w.value)
 
     def test_fluxd(self):
         synphot = pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
-        source = synphot.SourceSpectrum(synphot.Empirical1D, points=w,
-                                        lookup_table=f)
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
+        source = synphot.SourceSpectrum(
+            synphot.Empirical1D, points=w, lookup_table=f
+        )
         s = Star(source)
         assert np.allclose(s.fluxd.to(f.unit).value, f.value)
 
     def test_source(self):
         synphot = pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
-        source = synphot.SourceSpectrum(synphot.Empirical1D, points=w,
-                                        lookup_table=f)
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
+        source = synphot.SourceSpectrum(
+            synphot.Empirical1D, points=w, lookup_table=f
+        )
         s = Star(source)
         f = s.source(w)
         assert s.source == source
@@ -62,34 +65,33 @@ class TestSpectralStandard:
 
     def test_call_frequency(self):
         pytest.importorskip("synphot")
-        nu = u.Quantity(np.linspace(300, 1000), 'THz')
-        f = u.Quantity(0.5 * nu.value + 0.1, 'Jy')
+        nu = u.Quantity(np.linspace(300, 1000), "THz")
+        f = u.Quantity(0.5 * nu.value + 0.1, "Jy")
         s = Star.from_array(nu, f)
         nu = np.linspace(310, 999) * u.THz
         assert np.allclose(s(nu).value, 0.5 * nu.value + 0.1, rtol=0.002)
 
     def test_observe_units(self):
         pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)) * 0.35 / w.value, 'W/(m2 um)')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)) * 0.35 / w.value, "W/(m2 um)")
         s = Star.from_array(w, f)
         w = [0.3, 0.35, 0.4] * u.um
         a = s.observe(w)
-        b = s.observe(w, unit='W/(m2 Hz)')
+        b = s.observe(w, unit="W/(m2 Hz)")
         c = s.observe(w, unit=sbu.VEGAmag)
         d = s.observe(w, unit=u.ABmag)
+        assert np.allclose(a.value, b.to(a.unit, u.spectral_density(w)).value)
         assert np.allclose(
-            a.value, b.to(a.unit, u.spectral_density(w)).value)
-        assert np.allclose(
-            a.value, c.to(a.unit, sbu.spectral_density_vega(w)).value)
+            a.value, c.to(a.unit, sbu.spectral_density_vega(w)).value
+        )
         assert c.unit == sbu.VEGAmag
-        assert np.allclose(
-            a.value, d.to(a.unit, u.spectral_density(w)).value)
+        assert np.allclose(a.value, d.to(a.unit, u.spectral_density(w)).value)
 
     def test_observe_wavelength(self):
         pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)) * 0.35 / w.value, 'W/(m2 um)')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)) * 0.35 / w.value, "W/(m2 um)")
         s = Star.from_array(w, f)
         w = [0.3, 0.35, 0.4] * u.um
         assert np.isclose(s.observe(w).value[1], 1.0, rtol=0.001)
@@ -97,8 +99,8 @@ class TestSpectralStandard:
 
     def test_observe_frequency(self):
         pytest.importorskip("synphot")
-        nu = u.Quantity(np.linspace(300, 1000), 'THz')
-        f = u.Quantity(np.ones(len(nu)) * nu.value / 350, 'Jy')
+        nu = u.Quantity(np.linspace(300, 1000), "THz")
+        f = u.Quantity(np.ones(len(nu)) * nu.value / 350, "Jy")
         s = Star.from_array(nu, f)
         nu = [325, 350, 375] * u.THz
         assert np.isclose(s.observe(nu).value[1], 1.0, rtol=0.004)
@@ -106,29 +108,37 @@ class TestSpectralStandard:
     def test_observe_bandpass(self):
         synphot = pytest.importorskip("synphot")
 
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
         s = Star.from_array(w, f)
 
-        bp = synphot.SpectralElement(synphot.Box1D, x_0=0.55 * u.um,
-                                     width=0.1 * u.um)
+        bp = synphot.SpectralElement(
+            synphot.Box1D, x_0=0.55 * u.um, width=0.1 * u.um
+        )
         fluxd = s.observe(bp)
         assert np.allclose(fluxd.value, [1])
 
-        bps = [synphot.SpectralElement(synphot.Box1D, x_0=0.55 * u.um,
-                                       width=0.1 * u.um),
-               synphot.SpectralElement(synphot.Box1D, x_0=0.65 * u.um,
-                                       width=0.1 * u.um)]
-        fluxd = s.observe(bps, unit='W/(m2 um)')
+        bps = [
+            synphot.SpectralElement(
+                synphot.Box1D, x_0=0.55 * u.um, width=0.1 * u.um
+            ),
+            synphot.SpectralElement(
+                synphot.Box1D, x_0=0.65 * u.um, width=0.1 * u.um
+            ),
+        ]
+        fluxd = s.observe(bps, unit="W/(m2 um)")
         assert np.allclose(fluxd.value, [1, 1])
 
-        lambda_eff, fluxd = s.observe_bandpass(bps, unit='W/(m2 um)')
+        lambda_eff, fluxd = s.observe_bandpass(bps, unit="W/(m2 um)")
         assert np.allclose(fluxd.value, [1, 1])
 
     def test_observe_singlepointspectrumerror(self):
         pytest.importorskip("synphot")
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
+
+        from ...spectroscopy import sources
+
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
         s = Star.from_array(w, f)
         with pytest.raises(sources.SinglePointSpectrumError):
             s.observe(1 * u.um)
@@ -139,20 +149,21 @@ class TestSpectralStandard:
         pytest.importorskip("synphot")
         s = Star(None)
         s._fluxd_state = solar_fluxd
-        with solar_fluxd.set({'B': 0.327 * u.ABmag}):
-            fluxd = s.observe_filter_name('B', unit=u.ABmag)[-1]
+        with solar_fluxd.set({"B": 0.327 * u.ABmag}):
+            fluxd = s.observe_filter_name("B", unit=u.ABmag)[-1]
             assert fluxd.value == 0.327
 
         with pytest.raises(FilterLookupError):
-            fluxd = s.observe_filter_name('B', unit=u.ABmag)
+            fluxd = s.observe_filter_name("B", unit=u.ABmag)
 
     def test_observe_bad_wfb(self):
         synphot = pytest.importorskip("synphot")
 
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
-        source = synphot.SourceSpectrum(synphot.Empirical1D, points=w,
-                                        lookup_table=f)
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
+        source = synphot.SourceSpectrum(
+            synphot.Empirical1D, points=w, lookup_table=f
+        )
         s = Star(source)
         with pytest.raises(TypeError):
             s.observe(np.arange(5))
@@ -160,31 +171,33 @@ class TestSpectralStandard:
     def test_bibcode(self):
         pytest.importorskip("synphot")
 
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)) * 0.35 / w.value, 'W/(m2 um)')
-        s = Star.from_array(w, f, bibcode='asdf', description='fdsa')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)) * 0.35 / w.value, "W/(m2 um)")
+        s = Star.from_array(w, f, bibcode="asdf", description="fdsa")
 
         with bib.Tracking():
             s.source
 
-        assert 'asdf' in bib.show()
+        assert "asdf" in bib.show()
         bib.reset()
 
     def test_observe_vegamag(self):
         pytest.importorskip("synphot")
 
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)), 'W/(m2 um)')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)), "W/(m2 um)")
         s = Star.from_array(w, f)
-        V = bandpass('johnson v')
+        V = bandpass("johnson v")
         mag = s.observe(V, unit=sbu.VEGAmag)
         # -18.60 is -2.5 * log10(3636e-11)
         assert np.isclose(mag.value, -18.60, atol=0.02)
 
     @pytest.mark.parametrize(
-        'wfb, test, atol',
-        ((('johnson v', 'cousins i'), 0.0140 * sbu.VEGAmag, 0.004),
-         ((600 * u.nm, 750 * u.nm), -0.2422 * u.ABmag, 0.001))
+        "wfb, test, atol",
+        (
+            (("johnson v", "cousins i"), 0.0140 * sbu.VEGAmag, 0.004),
+            ((600 * u.nm, 750 * u.nm), -0.2422 * u.ABmag, 0.001),
+        ),
     )
     def test_color_index(self, wfb, test, atol):
         """Test color index.
@@ -204,10 +217,11 @@ class TestSpectralStandard:
 
         pytest.importorskip("synphot")
 
-        if type(wfb) is str:
-            wfb = bandpass(wfb)
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)) * w.value**-3, 'W/(m2 um)')
+        if isinstance(wfb[0], str):
+            wfb = (bandpass(wfb[0]), bandpass(wfb[1]))
+
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)) * w.value**-3, "W/(m2 um)")
         s = Star.from_array(w, f)
         eff_wave, ci = s.color_index(wfb, test.unit)
         assert np.isclose(ci.value, test.value, atol=atol)
@@ -215,8 +229,8 @@ class TestSpectralStandard:
     def test_color_index_typeerror(self):
         pytest.importorskip("synphot")
 
-        w = u.Quantity(np.linspace(0.3, 1.0), 'um')
-        f = u.Quantity(np.ones(len(w)) * w.value**-3, 'W/(m2 um)')
+        w = u.Quantity(np.linspace(0.3, 1.0), "um")
+        f = u.Quantity(np.ones(len(w)) * w.value**-3, "W/(m2 um)")
         s = Star.from_array(w, f)
         with pytest.raises(TypeError):
             s.color_index((None, None), u.ABmag)
@@ -225,58 +239,64 @@ class TestSpectralStandard:
 class Test_solar_spectrum:
     def test_validate_str(self):
         pytest.importorskip("synphot")
-        assert isinstance(solar_spectrum.validate('E490_2014'), Sun)
+        assert isinstance(solar_spectrum.validate("E490_2014"), Sun)
 
     def test_validate_Sun(self):
         pytest.importorskip("synphot")
         wave = [1, 2] * u.um
         fluxd = [1, 2] * u.Jy
-        sun = Sun.from_array(wave, fluxd, description='dummy source')
+        sun = Sun.from_array(wave, fluxd, description="dummy source")
         assert isinstance(solar_spectrum.validate(sun), Sun)
 
     def test_validate_error(self):
         with pytest.raises(TypeError):
             solar_spectrum.validate(1)
 
-    @pytest.mark.parametrize('name,source', (
-        ('E490_2014', solar_sources.SolarSpectra.E490_2014),
-        ('E490_2014LR', solar_sources.SolarSpectra.E490_2014LR))
+    @pytest.mark.parametrize(
+        "name,source",
+        (
+            ("E490_2014", solar_sources.SolarSpectra.E490_2014),
+            ("E490_2014LR", solar_sources.SolarSpectra.E490_2014LR),
+        ),
     )
     def test_set_string(self, name, source):
         pytest.importorskip("synphot")
         with solar_spectrum.set(name):
-            assert solar_spectrum.get().description == source['description']
+            assert solar_spectrum.get().description == source["description"]
 
     @pytest.mark.remote_data
-    @pytest.mark.parametrize('name,source', (
-        ('Kurucz1993', solar_sources.SolarSpectra.Kurucz1993),
-        ('Castelli1996', solar_sources.SolarSpectra.Castelli1996))
+    @pytest.mark.parametrize(
+        "name,source",
+        (
+            ("Kurucz1993", solar_sources.SolarSpectra.Kurucz1993),
+            ("Castelli1996", solar_sources.SolarSpectra.Castelli1996),
+        ),
     )
     def test_set_string_remote(self, name, source):
         pytest.importorskip("synphot")
         with solar_spectrum.set(name):
-            assert solar_spectrum.get().description == source['description']
+            assert solar_spectrum.get().description == source["description"]
 
     def test_set_source(self):
         pytest.importorskip("synphot")
         wave = [1, 2] * u.um
         fluxd = [1, 2] * u.Jy
-        source = Sun.from_array(wave, fluxd, description='dummy source')
+        source = Sun.from_array(wave, fluxd, description="dummy source")
         with solar_spectrum.set(source):
-            assert solar_spectrum.get().description == 'dummy source'
+            assert solar_spectrum.get().description == "dummy source"
 
 
 class Test_vega_spectrum:
     def test_validate_str(self):
         pytest.importorskip("synphot")
         # pytest.importorskip("synphot")
-        assert isinstance(vega_spectrum.validate('Bohlin2014'), Vega)
+        assert isinstance(vega_spectrum.validate("Bohlin2014"), Vega)
 
     def test_validate_Vega(self):
         pytest.importorskip("synphot")
         wave = [1, 2] * u.um
         fluxd = [1, 2] * u.Jy
-        vega = Vega.from_array(wave, fluxd, description='dummy source')
+        vega = Vega.from_array(wave, fluxd, description="dummy source")
         assert isinstance(vega_spectrum.validate(vega), Vega)
 
     def test_validate_error(self):
@@ -285,39 +305,42 @@ class Test_vega_spectrum:
 
     def test_set_string(self):
         pytest.importorskip("synphot")
-        with vega_spectrum.set('Bohlin2014'):
-            assert vega_spectrum.get(
-            ).description == vega_sources.VegaSpectra.Bohlin2014['description']
+        with vega_spectrum.set("Bohlin2014"):
+            assert (
+                vega_spectrum.get().description
+                == vega_sources.VegaSpectra.Bohlin2014["description"]
+            )
 
     def test_set_source(self):
         pytest.importorskip("synphot")
         wave = [1, 2] * u.um
         fluxd = [1, 2] * u.Jy
-        source = Vega.from_array(wave, fluxd, description='dummy source')
+        source = Vega.from_array(wave, fluxd, description="dummy source")
         with vega_spectrum.set(source):
-            assert vega_spectrum.get().description == 'dummy source'
+            assert vega_spectrum.get().description == "dummy source"
 
 
 class TestSolarFluxd:
     def test_willmer2018(self):
-        with solar_fluxd.set('Willmer2018'):
+        with solar_fluxd.set("Willmer2018"):
             filters = solar_fluxd.get()
-            assert np.isclose(filters['PS1 r'].value,
-                              10**(-0.4 * (21.1 - 26.66)))
-            assert filters['PS1 r'].unit == 'erg/(s cm2 AA)'
-            assert filters['PS1 r(lambda eff)'].value == 0.6156
-            assert filters['PS1 r(lambda eff)'].unit == u.um
-            assert filters['PS1 r(lambda pivot)'].value == 0.6201
-            assert filters['PS1 r(lambda pivot)'].unit == u.um
+            assert np.isclose(
+                filters["PS1 r"].value, 10 ** (-0.4 * (21.1 - 26.66))
+            )
+            assert filters["PS1 r"].unit == "erg/(s cm2 AA)"
+            assert filters["PS1 r(lambda eff)"].value == 0.6156
+            assert filters["PS1 r(lambda eff)"].unit == u.um
+            assert filters["PS1 r(lambda pivot)"].value == 0.6201
+            assert filters["PS1 r(lambda pivot)"].unit == u.um
 
 
 class TestVegaFluxd:
     def test_willmer2018(self):
-        with vega_fluxd.set('Willmer2018'):
+        with vega_fluxd.set("Willmer2018"):
             filters = vega_fluxd.get()
-            assert filters['PS1 r'].value == 2.53499e-09
-            assert filters['PS1 r'].unit == 'erg/(s cm2 AA)'
-            assert filters['PS1 r(lambda eff)'].value == 0.6156
-            assert filters['PS1 r(lambda eff)'].unit == u.um
-            assert filters['PS1 r(lambda pivot)'].value == 0.6201
-            assert filters['PS1 r(lambda pivot)'].unit == u.um
+            assert filters["PS1 r"].value == 2.53499e-09
+            assert filters["PS1 r"].unit == "erg/(s cm2 AA)"
+            assert filters["PS1 r(lambda eff)"].value == 0.6156
+            assert filters["PS1 r(lambda eff)"].unit == u.um
+            assert filters["PS1 r(lambda pivot)"].value == 0.6201
+            assert filters["PS1 r(lambda pivot)"].unit == u.um

--- a/sbpy/calib/tests/test_core.py
+++ b/sbpy/calib/tests/test_core.py
@@ -14,6 +14,7 @@ from .. import *
 class Star(SpectralStandard):
     pass
 
+
 class TestSpectralStandard:
     def test_from_array(self):
         pytest.importorskip("synphot")
@@ -263,6 +264,7 @@ class Test_solar_spectrum:
         source = Sun.from_array(wave, fluxd, description='dummy source')
         with solar_spectrum.set(source):
             assert solar_spectrum.get().description == 'dummy source'
+
 
 class Test_vega_spectrum:
     def test_validate_str(self):

--- a/sbpy/calib/tests/test_core.py
+++ b/sbpy/calib/tests/test_core.py
@@ -289,7 +289,6 @@ class Test_solar_spectrum:
 class Test_vega_spectrum:
     def test_validate_str(self):
         pytest.importorskip("synphot")
-        # pytest.importorskip("synphot")
         assert isinstance(vega_spectrum.validate("Bohlin2014"), Vega)
 
     def test_validate_Vega(self):

--- a/sbpy/calib/tests/test_sun.py
+++ b/sbpy/calib/tests/test_sun.py
@@ -8,16 +8,10 @@ from ...units import JMmag, VEGAmag
 from ...photometry import bandpass
 from .. import *
 
-try:
-    import scipy
-
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
 
 class TestSun:
     def test___repr__(self):
+        pytest.importorskip("synphot")
         with solar_spectrum.set("E490_2014LR"):
             assert repr(Sun.from_default()) == (
                 "<Sun: E490-00a (2014) low resolution reference "
@@ -28,6 +22,7 @@ class TestSun:
         assert repr(sun) == "<Sun>"
 
     def test_from_builtin(self):
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("E490_2014LR")
         assert (
             sun.description
@@ -39,6 +34,7 @@ class TestSun:
             Sun.from_builtin("not a solar spectrum")
 
     def test_from_default(self):
+        pytest.importorskip("synphot")
         with solar_spectrum.set("E490_2014LR"):
             sun = Sun.from_default()
             assert (
@@ -47,19 +43,22 @@ class TestSun:
             )
 
     def test_call_single_wavelength(self):
+        pytest.importorskip("synphot")
         with solar_spectrum.set("E490_2014"):
             sun = solar_spectrum.get()
             f = sun(0.5555 * u.um)
             assert np.isclose(f.value, 1897)
 
     def test_call_single_frequency(self):
+        pytest.importorskip("synphot")
         with solar_spectrum.set("E490_2014"):
             sun = solar_spectrum.get()
             f = sun(3e14 * u.Hz)
             assert np.isclose(f.value, 2.49484251e14)
 
-    @pytest.mark.skipif("not HAS_SCIPY")
     def test_sun_observe_wavelength_array(self):
+        pytest.importorskip("scipy")
+        pytest.importorskip("synphot")
         from scipy.integrate import trapz
 
         unit = "W/(m2 um)"
@@ -91,6 +90,7 @@ class TestSun:
         """Colina et al. V=-26.75 mag, for zero-point flux density
         36.7e-10 ergs/s/cm2/Å.
         """
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("E490_2014")
         V = bandpass("johnson v")
         weff, fluxd = sun.observe_bandpass(V, unit="erg/(s cm2 AA)")
@@ -104,6 +104,7 @@ class TestSun:
         agreement is good.
 
         """
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("E490_2014")
         V = bandpass("johnson v")
         fluxd = sun.observe(V, unit=JMmag)
@@ -116,6 +117,7 @@ class TestSun:
         optical.
 
         """
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("E490_2014")
         V = bandpass("johnson v")
         fluxd = sun.observe(V, unit=u.ABmag)
@@ -128,6 +130,7 @@ class TestSun:
         optical.
 
         """
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("E490_2014")
         V = bandpass("johnson v")
         fluxd = sun.observe(V, unit=u.STmag)
@@ -140,6 +143,7 @@ class TestSun:
         assert np.isclose(fluxd.value, -26.76)
 
     def test_meta(self):
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("E490_2014")
         assert sun.meta is None
 
@@ -152,6 +156,7 @@ class TestSun:
         NaNs in Kurucz file should not affect this calculation.
 
         """
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("Kurucz1993")
         V = bandpass("johnson v")
         fluxd = sun.observe(V, unit=u.ABmag)
@@ -171,7 +176,7 @@ class TestSun:
 
         2022-06-05: sbpy calculates 184.5 ergs/s/cm^2/A; agreement within 0.2%
         """
-
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("Castelli1996")
         V = bandpass("johnson v")
         fluxd = sun.observe(V, unit="erg/(s cm2 AA)")
@@ -180,7 +185,7 @@ class TestSun:
     @pytest.mark.remote_data
     def test_calspec(self):
         """Verify CALSPEC solar model calibration."""
-
+        pytest.importorskip("synphot")
         sun = Sun.from_builtin("calspec")
         V = bandpass("johnson v")
         fluxd = sun.observe(V, unit=VEGAmag)

--- a/sbpy/calib/tests/test_vega.py
+++ b/sbpy/calib/tests/test_vega.py
@@ -10,13 +10,16 @@ from .. import *
 
 pytest.importorskip("synphot")
 
+
 def patched_import_module(name):
     if name == "synphot":
         raise ModuleNotFoundError
     __import__(name)
 
+
 class Star(core.SpectralStandard):
     pass
+
 
 class TestVega:
     def test___repr__(self):

--- a/sbpy/calib/tests/test_vega.py
+++ b/sbpy/calib/tests/test_vega.py
@@ -1,5 +1,5 @@
-import sys
 import inspect
+import importlib
 import pytest
 import numpy as np
 import astropy.units as u
@@ -8,16 +8,15 @@ from ...photometry import bandpass
 from .. import core
 from .. import *
 
-try:
-    import scipy
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
+pytest.importorskip("synphot")
 
+def patched_import_module(name):
+    if name == "synphot":
+        raise ModuleNotFoundError
+    __import__(name)
 
 class Star(core.SpectralStandard):
     pass
-
 
 class TestVega:
     def test___repr__(self):
@@ -37,7 +36,7 @@ class TestVega:
         assert np.isclose(fluxd.value, fluxd0.value)
 
     def test_source_error(self, monkeypatch):
-        monkeypatch.setattr(core, 'synphot', None)
+        monkeypatch.setattr(importlib, "import_module", patched_import_module)
         vega = Vega.from_default()
         with pytest.raises(UndefinedSourceError):
             vega.source

--- a/sbpy/calib/tests/test_vega.py
+++ b/sbpy/calib/tests/test_vega.py
@@ -1,5 +1,5 @@
 import inspect
-import importlib
+from unittest.mock import patch
 import pytest
 import numpy as np
 import astropy.units as u
@@ -32,13 +32,9 @@ class TestVega:
         fluxd = vega(5557.5 * u.AA, unit=fluxd0.unit)
         assert np.isclose(fluxd.value, fluxd0.value)
 
+    @patch.dict("sys.modules", {"synphot": None})
     def test_source_error(self):
         # Only test when synphot is not available.
-        try:
-            import synphot
-            pytest.skip()
-        except ImportError:
-            pass
         vega = Vega.from_default()
         with pytest.raises(UndefinedSourceError):
             vega.source

--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -42,7 +42,8 @@ __all__ = ['Ephem']
 
 
 __doctest_requires__ = {
-    ('Ephem.from_oo',): ['pyoorb']
+    ("Ephem.from_oo",): ["pyoorb"],
+    ("Ephem.from_horizons", "Ephem.from_miriade", "Ephem.from_mpc"): ["astroquery"],
 }
 
 

--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -651,7 +651,7 @@ class Ephem(DataClass):
         return cls.from_table(all_eph)
 
     @classmethod
-    @requires("oorb")
+    @requires("pyoorb")
     @cite({'method': '2009M&PS...44.1853G',
            'software': 'https://github.com/oorb/oorb'})
     def from_oo(cls, orbit, epochs=None, location='500', scope='full',

--- a/sbpy/data/ephem.py
+++ b/sbpy/data/ephem.py
@@ -15,23 +15,28 @@ import numpy as np
 from numpy import ndarray, hstack, iterable
 from astropy.time import Time
 from astropy.table import vstack, Column, QTable
-from astropy.coordinates import Angle
+from astropy.coordinates import Angle, EarthLocation
 import astropy.units as u
-from astroquery.jplhorizons import Horizons
-from astroquery.mpc import MPC
-from astroquery.imcce import Miriade
-from astroquery.exceptions import InvalidQueryError
-from astropy.coordinates import EarthLocation
+
+# optional imports
+try:
+    from astroquery.jplhorizons import Horizons
+    from astroquery.mpc import MPC
+    from astroquery.imcce import Miriade
+    from astroquery.exceptions import InvalidQueryError
+except ImportError:
+    pass
 
 try:
     import pyoorb
 except ImportError:
-    pyoorb = None
+    pass
 
 from ..bib import cite
 from .core import DataClass, Conf, QueryError, TimeScaleWarning
 from ..exceptions import RequiredPackageUnavailable
 from .orbit import Orbit, OpenOrbError
+from ..utils.decorators import requires
 
 __all__ = ['Ephem']
 
@@ -45,8 +50,9 @@ class Ephem(DataClass):
     """Class for querying, manipulating, and calculating ephemerides"""
 
     @classmethod
-    @cite({'data source': '1996DPS....28.2504G'})
-    @cite({'software: astroquery': '2019AJ....157...98G'})
+    @requires("astroquery")
+    @cite({'data source': '1996DPS....28.2504G',
+           'software: astroquery': '2019AJ....157...98G'})
     def from_horizons(cls, targetids, id_type='smallbody',
                       epochs=None, location='500', **kwargs):
         """Load target ephemerides from
@@ -246,9 +252,10 @@ class Ephem(DataClass):
         return cls.from_table(all_eph)
 
     @classmethod
+    @requires("astroquery")
     @cite({'data source':
-           'https://minorplanetcenter.net/iau/MPEph/MPEph.html'})
-    @cite({'software: astroquery': '2019AJ....157...98G'})
+           'https://minorplanetcenter.net/iau/MPEph/MPEph.html',
+           'software: astroquery': '2019AJ....157...98G'})
     def from_mpc(cls, targetids, epochs=None, location='500', ra_format=None,
                  dec_format=None, **kwargs):
         """Load ephemerides from the
@@ -464,8 +471,9 @@ class Ephem(DataClass):
         return cls.from_table(all_eph)
 
     @classmethod
-    @cite({'data source': 'http://vo.imcce.fr/webservices/miriade/'})
-    @cite({'software: astroquery': '2019AJ....157...98G'})
+    @requires("astroquery")
+    @cite({'data source': 'http://vo.imcce.fr/webservices/miriade/',
+           'software: astroquery': '2019AJ....157...98G'})
     def from_miriade(cls, targetids, objtype='asteroid',
                      epochs=None, location='500', **kwargs):
         """Load target ephemerides from
@@ -643,6 +651,7 @@ class Ephem(DataClass):
         return cls.from_table(all_eph)
 
     @classmethod
+    @requires("oorb")
     @cite({'method': '2009M&PS...44.1853G',
            'software': 'https://github.com/oorb/oorb'})
     def from_oo(cls, orbit, epochs=None, location='500', scope='full',

--- a/sbpy/data/obs.py
+++ b/sbpy/data/obs.py
@@ -10,12 +10,18 @@ created on July 3, 2019
 """
 
 from astropy.time import Time
-from astroquery.mpc import MPC
+
+try:
+    from astroquery.mpc import MPC
+except ImportError:
+    pass
+
 from astropy.table import vstack, hstack
 
 from .ephem import Ephem
 from .core import QueryError
 from ..bib import cite
+from ..utils.decorators import requires
 
 __all__ = ['Obs']
 
@@ -24,9 +30,9 @@ class Obs(Ephem):
     """Class for querying, storing, and manipulating observations """
 
     @classmethod
-    @cite({'data source':
-           'https://minorplanetcenter.net/db_search'})
-    @cite({'software: astroquery': '2019AJ....157...98G'})
+    @requires("astroquery")
+    @cite({'data source': 'https://minorplanetcenter.net/db_search',
+           'software: astroquery': '2019AJ....157...98G'})
     def from_mpc(cls, targetid, id_type=None, **kwargs):
         """Load available observations for a target from the
         `Minor Planet Center <https://minorplanetcenter.net>`_ using
@@ -95,6 +101,7 @@ class Obs(Ephem):
 
         return cls.from_table(results)
 
+    @requires("astroquery")
     @cite({'software: astroquery': '2019AJ....157...98G'})
     def supplement(self, service='jplhorizons', id_field='targetname',
                    epoch_field='epoch', location='500',

--- a/sbpy/data/orbit.py
+++ b/sbpy/data/orbit.py
@@ -721,7 +721,6 @@ class Orbit(DataClass):
             in_orbits=in_orbits._to_oo(),
             in_epoch=ooepoch,
             in_dynmodel=dynmodel)
-        print(oo_orbits, err)
 
         if err != 0:
             OpenOrbError('pyoorb failed with error code {:d}'.format(err))

--- a/sbpy/data/orbit.py
+++ b/sbpy/data/orbit.py
@@ -7,7 +7,16 @@ sbpy data.Orbit Module
 Class for querying, manipulating, integrating, and fitting orbital elements.
 
 created on June 04, 2017
+
 """
+
+__all__ = ['Orbit', 'OrbitError', 'OpenOrbError']
+
+__doctest_requires__ = {
+    ("Orbit.oo_propagate", "Orbit.oo_transform"): ["pyoorb", "astroquery"],
+    ("Orbit.D_criterion", "Orbit.tisserand", "Orbit.from_horizons", "Orbit.from_mpc"): ["astroquery"],
+}
+
 import os
 import itertools
 from warnings import warn
@@ -33,9 +42,6 @@ from ..bib import cite, register
 from ..exceptions import RequiredPackageUnavailable, SbpyException
 from . import Conf, DataClass, QueryError, TimeScaleWarning
 from ..utils.decorators import requires
-
-
-__all__ = ['Orbit', 'OrbitError', 'OpenOrbError']
 
 
 class OrbitError(SbpyException):

--- a/sbpy/data/orbit.py
+++ b/sbpy/data/orbit.py
@@ -474,7 +474,7 @@ class Orbit(DataClass):
 
         return Orbit._from_oo(oo_orbits, orbittype, timescale)
 
-    @requires("oorb")
+    @requires("pyoorb")
     @cite({'method': '2009M&PS...44.1853G',
            'software': 'https://github.com/oorb/oorb'})
     def oo_transform(self, orbittype, ephfile='de430'):
@@ -589,7 +589,7 @@ class Orbit(DataClass):
 
         return orbits
 
-    @requires("oorb")
+    @requires("pyoorb")
     @cite({'method': '2009M&PS...44.1853G',
            'software': 'https://github.com/oorb/oorb'})
     def oo_propagate(self, epochs, dynmodel='N', ephfile='de430'):

--- a/sbpy/data/orbit.py
+++ b/sbpy/data/orbit.py
@@ -10,28 +10,30 @@ created on June 04, 2017
 """
 import os
 import itertools
+from warnings import warn
 import numpy as np
 from numpy import array, ndarray, double, arange
 from astropy.time import Time
 from astropy.table import vstack, QTable
-from astroquery.jplhorizons import Horizons
-from astroquery.mpc import MPC
 import astropy.units as u
-from warnings import warn
+
+# optional imports
+try:
+    from astroquery.jplhorizons import Horizons
+    from astroquery.mpc import MPC
+except ImportError:
+    pass
 
 try:
     import pyoorb
 except ImportError:
-    pyoorb = None
+    pass
 
 from ..bib import cite, register
 from ..exceptions import RequiredPackageUnavailable, SbpyException
 from . import Conf, DataClass, QueryError, TimeScaleWarning
+from ..utils.decorators import requires
 
-try:
-    import pyoorb
-except ImportError:
-    pyoorb = None
 
 __all__ = ['Orbit', 'OrbitError', 'OpenOrbError']
 
@@ -51,8 +53,9 @@ class Orbit(DataClass):
     elements"""
 
     @classmethod
-    @cite({'data source': '1996DPS....28.2504G'})
-    @cite({'software: astroquery': '2019AJ....157...98G'})
+    @requires("astroquery")
+    @cite({'data source': '1996DPS....28.2504G',
+           'software: astroquery': '2019AJ....157...98G'})
     def from_horizons(cls, targetids, id_type='smallbody',
                       epochs=None, center='500@10',
                       **kwargs):
@@ -193,9 +196,9 @@ class Orbit(DataClass):
         return cls.from_table(all_elem)
 
     @classmethod
-    @cite({'data source':
-           'https://minorplanetcenter.net/iau/MPEph/MPEph.html'})
-    @cite({'software: astroquery': '2019AJ....157...98G'})
+    @requires("astroquery")
+    @cite({'data source': 'https://minorplanetcenter.net/iau/MPEph/MPEph.html',
+           'software: astroquery': '2019AJ....157...98G'})
     def from_mpc(cls, targetids, id_type=None, target_type=None, **kwargs):
         """Load latest orbital elements from the
         `Minor Planet Center <https://minorplanetcenter.net>`_.
@@ -471,6 +474,7 @@ class Orbit(DataClass):
 
         return Orbit._from_oo(oo_orbits, orbittype, timescale)
 
+    @requires("oorb")
     @cite({'method': '2009M&PS...44.1853G',
            'software': 'https://github.com/oorb/oorb'})
     def oo_transform(self, orbittype, ephfile='de430'):
@@ -585,6 +589,7 @@ class Orbit(DataClass):
 
         return orbits
 
+    @requires("oorb")
     @cite({'method': '2009M&PS...44.1853G',
            'software': 'https://github.com/oorb/oorb'})
     def oo_propagate(self, epochs, dynmodel='N', ephfile='de430'):

--- a/sbpy/data/phys.py
+++ b/sbpy/data/phys.py
@@ -9,6 +9,12 @@ Class for storing and querying physical properties
 created on June 04, 2017
 """
 
+__all__ = ["Phys"]
+
+__doctest_requires__ = {
+    "Phys.from_sbdb": ["astroquery"],
+}
+
 from collections import OrderedDict
 
 import numpy as np
@@ -25,8 +31,6 @@ from .core import DataClass
 from ..bib import cite
 from ..exceptions import SbpyException
 from ..utils.decorators import requires
-
-__all__ = ['Phys']
 
 
 class JPLSpecQueryFailed(SbpyException):

--- a/sbpy/data/phys.py
+++ b/sbpy/data/phys.py
@@ -13,12 +13,18 @@ from collections import OrderedDict
 
 import numpy as np
 import astropy.units as u
-from astroquery.jplsbdb import SBDB
-from astroquery.jplspec import JPLSpec
+
+# optional package
+try:
+    from astroquery.jplsbdb import SBDB
+    from astroquery.jplspec import JPLSpec
+except ImportError:
+    pass
 
 from .core import DataClass
 from ..bib import cite
 from ..exceptions import SbpyException
+from ..utils.decorators import requires
 
 __all__ = ['Phys']
 
@@ -33,6 +39,7 @@ class Phys(DataClass):
     """Class for storing and querying physical properties"""
 
     @classmethod
+    @requires("astroquery")
     @cite({'software: astroquery': '2019AJ....157...98G'})
     def from_sbdb(cls, targetids, references=False, notes=False):
         """Load physical properties from `JPL Small-Body Database (SBDB)
@@ -181,6 +188,7 @@ class Phys(DataClass):
         return cls.from_columns(coldata, names=columnnames)
 
     @classmethod
+    @requires("astroquery")
     @cite({'software: astroquery': '2019AJ....157...98G'})
     def from_jplspec(cls, temp_estimate, transition_freq, mol_tag):
         """Constants from JPLSpec catalog and energy calculations

--- a/sbpy/data/tests/test_ephem.py
+++ b/sbpy/data/tests/test_ephem.py
@@ -7,13 +7,7 @@ from astropy.time import Time
 
 from ... import exceptions as sbe
 from ... import bib
-from .. import ephem
 from .. import Ephem, Orbit
-
-try:
-    import pyoorb
-except ImportError:
-    pyoorb = None
 
 # retreived from Horizons on 23 Apr 2020
 CERES = {
@@ -36,14 +30,10 @@ CERES = {
 }
 
 
-@pytest.mark.skipif('pyoorb is None')
 class TestEphemFromOorb:
-    def test_missing_pyoorb(self, monkeypatch):
-        monkeypatch.setattr(ephem, 'pyoorb', None)
-        with pytest.raises(sbe.RequiredPackageUnavailable):
-            Ephem.from_oo(CERES)
-
     def test_units(self):
+        pytest.importorskip("pyoorb")
+
         orbit1 = Orbit.from_dict(CERES)
         eph1 = Ephem.from_oo(orbit1)
 
@@ -66,17 +56,23 @@ class TestEphemFromOorb:
             assert u.isclose(eph1[k], eph2[k])
 
     def test_basic(self):
+        pytest.importorskip("pyoorb")
+
         orbit = Orbit.from_dict(CERES)
         oo_ephem = Ephem.from_oo(orbit, scope='basic')
         assert 'dec_rate' not in oo_ephem.field_names
 
     def test_timescale(self):
+        pytest.importorskip("pyoorb")
+
         orbit = Orbit.from_dict(CERES)
         epoch = Time.now()
         oo_ephem = Ephem.from_oo(orbit, epochs=epoch, scope='basic')
         assert oo_ephem['epoch'].scale == epoch.scale
 
     def test_bib(self):
+        pytest.importorskip("pyoorb")
+
         with bib.Tracking():
             orbit = Orbit.from_dict(CERES)
             oo_ephem = Ephem.from_oo(orbit, scope='basic')

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -14,10 +14,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from ... import bib
 from .. import Ephem, Orbit, QueryError
 
-try:
-    import pyoorb
-except ImportError:
-    pyoorb = None
+pytest.importorskip("astroquery")
 
 # retreived from Horizons on 23 Apr 2020
 CERES = {
@@ -407,10 +404,11 @@ class TestEphemFromMiriade:
 
 
 @pytest.mark.remote_data
-@pytest.mark.skipif('pyoorb is None')
 class TestEphemFromOorb:
     def test_by_comparison(self):
         """test from_oo method"""
+
+        pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_horizons('Ceres')
         horizons_ephem = Ephem.from_horizons('Ceres', location='500')

--- a/sbpy/data/tests/test_obs_remote.py
+++ b/sbpy/data/tests/test_obs_remote.py
@@ -9,6 +9,8 @@ from .. import Obs
 from ... import bib
 from ..core import QueryError
 
+pytest.importorskip("astroquery")
+
 
 @pytest.mark.remote_data
 class TestObsfromMPC:

--- a/sbpy/data/tests/test_orbit.py
+++ b/sbpy/data/tests/test_orbit.py
@@ -140,7 +140,7 @@ class TestOOPropagate:
 
     def test_oo_propagate(self):
         """ test oo_propagate method"""
-        
+
         pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_dict(CERES)

--- a/sbpy/data/tests/test_orbit.py
+++ b/sbpy/data/tests/test_orbit.py
@@ -10,11 +10,6 @@ from ... import exceptions as sbe
 from .. import orbit as sbo
 from ..orbit import Orbit
 
-try:
-    import pyoorb  # noqa
-except ImportError:
-    pyoorb = None
-
 # CERES and CERES2 retrieved from Horizons on 24 Sep 2021
 CERES = {
     'targetname': '1 Ceres (A801 AA)',
@@ -56,15 +51,11 @@ CERES2 = {  # CERES epoch + 100 days
 }
 
 
-@pytest.mark.skipif('pyoorb is None')
 class TestOOTransform:
-    def test_missing_pyoorb(self, monkeypatch):
-        monkeypatch.setattr(sbo, 'pyoorb', None)
-        with pytest.raises(sbe.RequiredPackageUnavailable):
-            Orbit.from_dict(CERES).oo_transform('CART')
-
     def test_oo_transform_kep(self):
         """ test oo_transform method"""
+
+        pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_dict(CERES)
 
@@ -90,6 +81,8 @@ class TestOOTransform:
 
     def test_oo_transform_com(self):
         """ test oo_transform method"""
+
+        pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_dict(CERES)
 
@@ -121,6 +114,8 @@ class TestOOTransform:
 
     def test_timescales(self):
         """ test with input in UTC scale """
+        pytest.importorskip("pyoorb")
+
         orbit = Orbit.from_dict(CERES)
         orbit['epoch'] = orbit['epoch'].utc
 
@@ -141,15 +136,12 @@ class TestOOTransform:
         assert kep_orbit['epoch'].scale == 'utc'
 
 
-@pytest.mark.skipif('pyoorb is None')
 class TestOOPropagate:
-    def test_missing_pyoorb(self, monkeypatch):
-        monkeypatch.setattr(sbo, 'pyoorb', None)
-        with pytest.raises(sbe.RequiredPackageUnavailable):
-            Orbit.from_dict(CERES).oo_transform('CART')
 
     def test_oo_propagate(self):
         """ test oo_propagate method"""
+        
+        pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_dict(CERES)
         future_orbit = Orbit.from_dict(CERES2)

--- a/sbpy/data/tests/test_orbit_remote.py
+++ b/sbpy/data/tests/test_orbit_remote.py
@@ -140,7 +140,7 @@ class TestOOTransform:
 
     def test_timescales(self):
         pytest.importorskip("pyoorb")
-        
+
         orbit = Orbit.from_horizons('Ceres')
         orbit['epoch'] = orbit['epoch'].tdb
 

--- a/sbpy/data/tests/test_orbit_remote.py
+++ b/sbpy/data/tests/test_orbit_remote.py
@@ -100,7 +100,7 @@ class TestOrbitFromMPC:
         assert len(a) == 1
 
     def test_multiple(self):
-        a = Orbit.from_mpc(['1P', '2P', '3P'])
+        a = Orbit.from_mpc(["1P", "2P", "4P"])
         assert len(a) == 3
 
     def test_break(self):

--- a/sbpy/data/tests/test_orbit_remote.py
+++ b/sbpy/data/tests/test_orbit_remote.py
@@ -11,15 +11,11 @@ from ..orbit import Orbit, QueryError
 from ..names import TargetNameParseError
 from ... import bib
 
-try:
-    import pyoorb
-except ImportError:
-    pyoorb = None
+pytest.importorskip("astroquery")
 
 
 @pytest.mark.remote_data
 class TestOrbitFromHorizons:
-
     def test_now(self):
         # current epoch
         now = Time.now()
@@ -112,11 +108,12 @@ class TestOrbitFromMPC:
             Orbit.from_mpc('does not exist')
 
 
-@pytest.mark.skipif('pyoorb is None')
 @pytest.mark.remote_data
 class TestOOTransform:
     def test_oo_transform(self):
         """ test oo_transform method"""
+
+        pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_horizons('Ceres')
 
@@ -142,7 +139,8 @@ class TestOOTransform:
         u.isclose(orbit['epoch'][0].utc.jd, kep_orbit['epoch'][0].utc.jd)
 
     def test_timescales(self):
-
+        pytest.importorskip("pyoorb")
+        
         orbit = Orbit.from_horizons('Ceres')
         orbit['epoch'] = orbit['epoch'].tdb
 
@@ -170,11 +168,12 @@ class TestOOTransform:
         assert kep_orbit['epoch'].scale == 'tdb'
 
 
-@pytest.mark.skipif('pyoorb is None')
 @pytest.mark.remote_data
 class TestOOPropagate:
     def test_oo_propagate(self):
         """ test oo_propagate method"""
+
+        pytest.importorskip("pyoorb")
 
         orbit = Orbit.from_horizons('Ceres')
         epoch = Time(Time.now().jd + 100, format='jd', scale='utc')

--- a/sbpy/data/tests/test_phys_remote.py
+++ b/sbpy/data/tests/test_phys_remote.py
@@ -6,6 +6,7 @@ from sbpy.data import Phys
 
 pytest.importorskip("astroquery")
 
+
 @pytest.mark.remote_data
 def test_from_sbdb():
     """ test from_sbdb method"""

--- a/sbpy/data/tests/test_phys_remote.py
+++ b/sbpy/data/tests/test_phys_remote.py
@@ -4,6 +4,7 @@ import pytest
 import astropy.units as u
 from sbpy.data import Phys
 
+pytest.importorskip("astroquery")
 
 @pytest.mark.remote_data
 def test_from_sbdb():

--- a/sbpy/photometry/bandpass.py
+++ b/sbpy/photometry/bandpass.py
@@ -9,9 +9,10 @@ __all__ = [
 ]
 
 import os
-from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.data import get_pkg_data_path
+from ..utils.decorators import requires
 
-
+@requires("synphot")
 def bandpass(name):
     """Retrieve bandpass transmission spectrum from sbpy.
 
@@ -113,10 +114,7 @@ def bandpass(name):
 
     """
 
-    try:
-        import synphot
-    except ImportError:
-        raise ImportError('synphot is required.')
+    import synphot
 
     name2file = {
         '2mass j': '2mass-j-rsr.txt',
@@ -156,7 +154,7 @@ def bandpass(name):
         'ps1 z': 'nm',
     }
 
-    fn = get_pkg_data_filename(os.path.join(
+    fn = get_pkg_data_path(os.path.join(
         '..', 'photometry', 'data', name2file[name.lower()]))
     bp = synphot.SpectralElement.from_file(
         fn, wave_unit=wave_unit.get(name.lower(), 'AA'))

--- a/sbpy/photometry/bandpass.py
+++ b/sbpy/photometry/bandpass.py
@@ -12,6 +12,7 @@ import os
 from astropy.utils.data import get_pkg_data_path
 from ..utils.decorators import requires
 
+
 @requires("synphot")
 def bandpass(name):
     """Retrieve bandpass transmission spectrum from sbpy.

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -16,6 +16,7 @@ __doctest_requires__ = {
      "LinearPhaseFunc",
      "LinearPhaseFunc._phase_integral"
      ): ["scipy"],
+    ("DiskIntegratedPhaseFunc.from_phys", "DiskIntegratedPhaseFunc.to_phys"): ["astroquery"],
 }
 
 from collections import OrderedDict

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -9,9 +9,23 @@ created on June 23, 2017
 __all__ = ['DiskIntegratedPhaseFunc', 'LinearPhaseFunc',
            'InvalidPhaseFunctionWarning']
 
+__doctest_requires__ = {
+    ("DiskIntegratedPhaseFunc",
+     "DiskIntegratedPhaseFunc._phase_integral",
+     "DiskIntegratedPhaseFunc.from_obs",
+     "LinearPhaseFunc",
+     "LinearPhaseFunc._phase_integral"
+    ): ["scipy"],
+}
+
 from collections import OrderedDict
 import numpy as np
-from scipy.integrate import quad
+
+try:
+    from scipy.integrate import quad
+except ImportError:
+    quad = None
+
 from astropy.modeling import (Fittable1DModel, Parameter)
 import astropy.units as u
 from astropy import log
@@ -19,6 +33,7 @@ from ..data import (Phys, Obs, Ephem, dataclass_input,
                     quantity_to_dataclass)
 from ..units import reflectance
 from ..exceptions import SbpyWarning
+from ..utils.decorators import requires
 
 
 class InvalidPhaseFunctionWarning(SbpyWarning):
@@ -650,6 +665,7 @@ class DiskIntegratedPhaseFunc(Fittable1DModel):
         else:
             return out
 
+    @requires("scipy")
     def _phase_integral(self, integrator=quad):
         """Calculate phase integral with numerical integration
 

--- a/sbpy/photometry/core.py
+++ b/sbpy/photometry/core.py
@@ -15,7 +15,7 @@ __doctest_requires__ = {
      "DiskIntegratedPhaseFunc.from_obs",
      "LinearPhaseFunc",
      "LinearPhaseFunc._phase_integral"
-    ): ["scipy"],
+     ): ["scipy"],
 }
 
 from collections import OrderedDict

--- a/sbpy/photometry/iau.py
+++ b/sbpy/photometry/iau.py
@@ -7,17 +7,20 @@ created on July, 2022
 
 """
 
+
+__all__ = ['HG', 'HG12', 'HG1G2', 'HG12_Pen16']
+
+__doctest_requires__ = {
+    "HG*": ["scipy"],
+}
+
 import warnings
 from collections import OrderedDict
 import numpy as np
-from scipy.integrate import quad
 from astropy.modeling import Parameter
 import astropy.units as u
 from .core import DiskIntegratedPhaseFunc, InvalidPhaseFunctionWarning
 from ..bib import cite
-
-
-__all__ = ['HG', 'HG12', 'HG1G2', 'HG12_Pen16']
 
 
 # define the bounds of various model parameters

--- a/sbpy/photometry/tests/test_bandpass.py
+++ b/sbpy/photometry/tests/test_bandpass.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from unittest.mock import patch
 import pytest
 import numpy as np
 from ..bandpass import *
@@ -44,13 +45,7 @@ def test_bandpass(name, avgwave):
     assert np.isclose(bp.avgwave().value, avgwave)
 
 
+@patch.dict("sys.modules", {"synphot": None})
 def test_bandpass_synphot():
-    # skip if synphot is available
-    try:
-        import synphot
-
-        pytest.skip()
-    except ImportError:
-        pass
     with pytest.raises(RequiredPackageUnavailable):
         bandpass("sdss u")

--- a/sbpy/photometry/tests/test_bandpass.py
+++ b/sbpy/photometry/tests/test_bandpass.py
@@ -4,10 +4,8 @@ import sys
 from unittest import mock
 import pytest
 import numpy as np
-
-synphot = pytest.importorskip("synphot")
-
 from ..bandpass import *
+from ...exceptions import RequiredPackageUnavailable
 
 
 @pytest.mark.parametrize('name, avgwave', (
@@ -44,7 +42,12 @@ def test_bandpass(name, avgwave):
     assert np.isclose(bp.avgwave().value, avgwave)
 
 
-@mock.patch.dict(sys.modules, {'synphot': None})
 def test_bandpass_synphot():
-        with pytest.raises(ImportError):
-            bandpass('sdss u')
+    # skip if synphot is available
+    try:
+        import synphot
+        pytest.skip()
+    except ImportError:
+        pass
+    with pytest.raises(RequiredPackageUnavailable):
+        bandpass('sdss u')

--- a/sbpy/photometry/tests/test_bandpass.py
+++ b/sbpy/photometry/tests/test_bandpass.py
@@ -1,43 +1,45 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import sys
-from unittest import mock
 import pytest
 import numpy as np
 from ..bandpass import *
 from ...exceptions import RequiredPackageUnavailable
 
 
-@pytest.mark.parametrize('name, avgwave', (
-    ('2mass j', 12410.52630476),
-    ('2mass h', 16513.66475736),
-    ('2mass ks', 21656.32078498),
-    ('atlas c', 5408.72465833),
-    ('atlas o', 6866.26069039),
-    ('cousins r', 6499.91478190),
-    ('cousins i', 7884.10581303),
-    ('johnson u', 3598.54452094),
-    ('johnson b', 4385.9244053),
-    ('johnson v', 5490.55520036),
-    ('ps1 g', 4866.4578708),
-    ('ps1 r', 6214.623038),
-    ('ps1 i', 7544.570357),
-    ('ps1 w', 6389.3518241),
-    ('ps1 y', 9633.2481028),
-    ('ps1 z', 8679.46803),
-    ('sdss u', 3561.78873418),
-    ('sdss g', 4718.87224631),
-    ('sdss r', 6185.19447698),
-    ('sdss i', 7499.70417489),
-    ('sdss z', 8961.48833667),
-    ('wfc3 f438w', 4324.44438089),
-    ('wfc3 f606w', 5946.7429129),
-    ('wise w1', 34002.59750555),
-    ('wise w2', 46520.16384937),
-    ('wise w3', 128108.72187073),
-    ('wise w4', 223752.74423983),
-))
+@pytest.mark.parametrize(
+    "name, avgwave",
+    (
+        ("2mass j", 12410.52630476),
+        ("2mass h", 16513.66475736),
+        ("2mass ks", 21656.32078498),
+        ("atlas c", 5408.72465833),
+        ("atlas o", 6866.26069039),
+        ("cousins r", 6499.91478190),
+        ("cousins i", 7884.10581303),
+        ("johnson u", 3598.54452094),
+        ("johnson b", 4385.9244053),
+        ("johnson v", 5490.55520036),
+        ("ps1 g", 4866.4578708),
+        ("ps1 r", 6214.623038),
+        ("ps1 i", 7544.570357),
+        ("ps1 w", 6389.3518241),
+        ("ps1 y", 9633.2481028),
+        ("ps1 z", 8679.46803),
+        ("sdss u", 3561.78873418),
+        ("sdss g", 4718.87224631),
+        ("sdss r", 6185.19447698),
+        ("sdss i", 7499.70417489),
+        ("sdss z", 8961.48833667),
+        ("wfc3 f438w", 4324.44438089),
+        ("wfc3 f606w", 5946.7429129),
+        ("wise w1", 34002.59750555),
+        ("wise w2", 46520.16384937),
+        ("wise w3", 128108.72187073),
+        ("wise w4", 223752.74423983),
+    ),
+)
 def test_bandpass(name, avgwave):
+    pytest.importorskip("synphot")
     bp = bandpass(name)
     assert np.isclose(bp.avgwave().value, avgwave)
 
@@ -46,8 +48,9 @@ def test_bandpass_synphot():
     # skip if synphot is available
     try:
         import synphot
+
         pytest.skip()
     except ImportError:
         pass
     with pytest.raises(RequiredPackageUnavailable):
-        bandpass('sdss u')
+        bandpass("sdss u")

--- a/sbpy/photometry/tests/test_bandpass.py
+++ b/sbpy/photometry/tests/test_bandpass.py
@@ -9,6 +9,7 @@ synphot = pytest.importorskip("synphot")
 
 from ..bandpass import *
 
+
 @pytest.mark.parametrize('name, avgwave', (
     ('2mass j', 12410.52630476),
     ('2mass h', 16513.66475736),

--- a/sbpy/photometry/tests/test_bandpass.py
+++ b/sbpy/photometry/tests/test_bandpass.py
@@ -1,11 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import sys
-import mock
+from unittest import mock
 import pytest
 import numpy as np
-from ..bandpass import *
 
+synphot = pytest.importorskip("synphot")
+
+from ..bandpass import *
 
 @pytest.mark.parametrize('name, avgwave', (
     ('2mass j', 12410.52630476),
@@ -41,7 +43,7 @@ def test_bandpass(name, avgwave):
     assert np.isclose(bp.avgwave().value, avgwave)
 
 
+@mock.patch.dict(sys.modules, {'synphot': None})
 def test_bandpass_synphot():
-    with mock.patch.dict(sys.modules, {'synphot': None}):
         with pytest.raises(ImportError):
             bandpass('sdss u')

--- a/sbpy/photometry/tests/test_core.py
+++ b/sbpy/photometry/tests/test_core.py
@@ -133,6 +133,7 @@ class TestLinear():
             linphase.to_ref(10 * u.deg)
 
     def test_props(self):
+        pytest.importorskip("scipy")
         linphase = LinearPhaseFunc(5 * u.mag, 2.29 * u.mag/u.rad,
                                    radius=300 * u.km, wfb='V')
         assert np.isclose(linphase.geomalb, 0.0487089)
@@ -148,6 +149,7 @@ class TestLinear():
         assert np.allclose(module, module_test)
 
     def test_fit(self):
+        pytest.importorskip("scipy")
         pha = np.linspace(0, 60, 100) * u.deg
         mag = LinearPhaseFunc(5 * u.mag, 0.04 * u.mag/u.deg)(pha) + \
             (np.random.rand(100)*0.2-0.1) * u.mag

--- a/sbpy/photometry/tests/test_iau.py
+++ b/sbpy/photometry/tests/test_iau.py
@@ -61,6 +61,7 @@ class TestHG:
             m = HG.from_phys(phys)
 
     def test_to_phys(self):
+        pytest.importorskip("scipy")
         m = HG(3.34 * u.mag, 0.12)
         p = m.to_phys()
         assert isinstance(p, Phys)
@@ -105,12 +106,14 @@ class TestHG:
         assert ceres._unit == 'mag'
 
     def test_props(self):
+        pytest.importorskip("scipy")
         ceres = HG(3.34 * u.mag, 0.12, radius=480 * u.km, wfb='V')
         assert np.isclose(ceres.geomalb, 0.0877745)
         assert np.isclose(ceres.bondalb, 0.03198069)
         assert np.isclose(ceres.phaseint, 0.3643505755292945)
 
     def test_from_obs(self):
+        pytest.importorskip("scipy")
         pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
                31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
                63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
@@ -284,6 +287,7 @@ class TestHG1G2:
         assert np.isclose(themis.phaseint, 0.374152)
 
     def test_from_obs(self):
+        pytest.importorskip("scipy")
         pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
                31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
                63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
@@ -383,6 +387,7 @@ class TestHG12:
         assert np.isclose(themis.oe_amp, 0.23412300750840437)
 
     def test_from_obs(self):
+        pytest.importorskip("scipy")
         pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
                31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
                63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,
@@ -476,6 +481,7 @@ class TestHG12_Pen16:
         assert np.isclose(themis.phaseint, 0.38042683486452)
 
     def test_from_obs(self):
+        pytest.importorskip("scipy")
         pha = [0., 6.31578947, 12.63157895, 18.94736842, 25.26315789,
                31.57894737, 37.89473684, 44.21052632, 50.52631579, 56.84210526,
                63.15789474, 69.47368421, 75.78947368, 82.10526316, 88.42105263,

--- a/sbpy/photometry/tests/test_iau.py
+++ b/sbpy/photometry/tests/test_iau.py
@@ -44,6 +44,8 @@ class TestHG:
 
     @pytest.mark.remote_data
     def test_from_phys(self):
+        pytest.importorskip("astroquery")
+
         # test initialization from `sbpy.data.DataClass`
         phys = Phys.from_sbdb('Ceres')
         m = HG.from_phys(phys)
@@ -241,6 +243,8 @@ class TestHG1G2:
 
     @pytest.mark.remote_data
     def test_from_phys(self):
+        pytest.importorskip("astroquery")
+
         # initialization with Phys, will cause exception because G1, G2 are
         # not generally unavailable.
         phys = Phys.from_sbdb(['Ceres'])

--- a/sbpy/spectroscopy/core.py
+++ b/sbpy/spectroscopy/core.py
@@ -6,28 +6,16 @@ created on June 23, 2017
 """
 
 import numpy as np
-import astropy.constants as con
 import astropy.units as u
-from astropy.time import Time
-from astroquery.jplhorizons import Horizons, conf
-from astropy import log
-from ..bib import register
-from ..data import Phys
-
-
-try:
-    from synphot import SpectralElement
-except ImportError:
-    class SpectralElement:
-        pass
 
 
 __all__ = ['Spectrum', 'SpectralModel', 'SpectralGradient']
 
 __doctest_requires__ = {
-    "SpectralGradient": ["astropy>=5.3"],
-    "SpectralGradient.from_color": ["astropy>=5.3"],
-    "SpectralGradient.renormalize": ["astropy>=5.3"],
+    "SpectralGradient": ["astropy>=5.3", "synphot"],
+    "SpectralGradient.from_color": ["astropy>=5.3", "synphot"],
+    "SpectralGradient.to_color": ["synphot"],
+    "SpectralGradient.renormalize": ["astropy>=5.3", "synphot"],
 }
 
 

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -43,7 +43,7 @@ class SinglePointSpectrumError(SbpyException):
     """Single point provided, but multiple values expected."""
 
 
-@deprecated("v0.4.1")
+@deprecated("v0.5.0")
 class SynphotRequired(SbpyException):
     pass
 

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -42,6 +42,7 @@ __doctest_requires__ = {
 class SinglePointSpectrumError(SbpyException):
     """Single point provided, but multiple values expected."""
 
+
 @deprecated("v0.4.1")
 class SynphotRequired(SbpyException):
     pass

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -484,7 +484,7 @@ class SpectralSource(ABC):
         red_spec._source = red_spec.source * r
         if red_spec.description is not None:
             red_spec._description = '{} reddened by {} at {}'.format(
-                    red_spec.description, S, S.wave0)
+                red_spec.description, S, S.wave0)
         return red_spec
 
 

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -15,6 +15,7 @@ from ...units import hundred_nm
 V = bandpass('johnson v')
 I = bandpass('cousins i')
 
+
 class Star(SpectralSource):
     def __init__(self):
         super().__init__(synphot.SourceSpectrum(

--- a/sbpy/spectroscopy/tests/test_sources.py
+++ b/sbpy/spectroscopy/tests/test_sources.py
@@ -5,17 +5,15 @@ import numpy as np
 import astropy.units as u
 from astropy.modeling.models import BlackBody
 import astropy.constants as const
-import synphot
-from .. import sources
-from ..sources import (BlackbodySource, SpectralSource, SynphotRequired,
-                       Reddening)
+synphot = pytest.importorskip("synphot")
+
+from ..sources import (BlackbodySource, SpectralSource, Reddening)
 from ..core import SpectralGradient
 from ...photometry import bandpass
 from ...units import hundred_nm
 
 V = bandpass('johnson v')
 I = bandpass('cousins i')
-
 
 class Star(SpectralSource):
     def __init__(self):
@@ -24,11 +22,6 @@ class Star(SpectralSource):
 
 
 class TestSpectralSource:
-    def test_init_error(self, monkeypatch):
-        with pytest.raises(SynphotRequired):
-            monkeypatch.setattr(sources, 'synphot', None)
-            Star()
-
     @pytest.mark.parametrize('wfb, interpolate', (
         ([V], False),
         ([1] * u.um, True),

--- a/sbpy/spectroscopy/tests/test_specgrad.py
+++ b/sbpy/spectroscopy/tests/test_specgrad.py
@@ -11,8 +11,10 @@ try:
 except ModuleNotFoundError:
     # do nothing function so that the TestSpectralGradient class can compile
     synphot = None
+
     def bandpass(bp):
         pass
+
 
 @pytest.mark.skipif("synphot is None")
 class TestSpectralGradient():

--- a/sbpy/spectroscopy/tests/test_specgrad.py
+++ b/sbpy/spectroscopy/tests/test_specgrad.py
@@ -1,11 +1,20 @@
+import pytest
 import numpy as np
 import astropy.units as u
 import pytest
 from ...units import hundred_nm
-from ...photometry import bandpass
 from ..core import SpectralGradient
 
+try:
+    import synphot
+    from ...photometry import bandpass
+except ModuleNotFoundError:
+    # do nothing function so that the TestSpectralGradient class can compile
+    synphot = None
+    def bandpass(bp):
+        pass
 
+@pytest.mark.skipif("synphot is None")
 class TestSpectralGradient():
     def test_new(self):
         S = SpectralGradient(100 / u.um, wave=(525, 575) * u.nm)

--- a/sbpy/spectroscopy/tests/test_specgrad.py
+++ b/sbpy/spectroscopy/tests/test_specgrad.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:
         pass
 
 
-@pytest.mark.skipif("synphot is None")
+@pytest.mark.skipif(synphot is None, reason="requires synphot")
 class TestSpectralGradient():
     def test_new(self):
         S = SpectralGradient(100 / u.um, wave=(525, 575) * u.nm)

--- a/sbpy/thermal/core.py
+++ b/sbpy/thermal/core.py
@@ -7,6 +7,10 @@ created on June 27, 2017
 
 __all__ = ['ThermalClass', 'STM', 'FRM', 'NEATM']
 
+__doctest_requires__ = {
+    "ThermalClass.flux": "astroquery"
+}
+
 
 class ThermalClass():
 

--- a/sbpy/units/core.py
+++ b/sbpy/units/core.py
@@ -26,17 +26,20 @@ __all__ = [
     'projected_size',
 ]
 
+__doctest_requires__ = {
+    "spectral_density_vega": ["synphot"]
+}
+
 from warnings import warn
 import numpy as np
 import astropy.units as u
 import astropy.constants as const
-from ..exceptions import SbpyWarning
 from ..calib import (
     Vega, Sun, vega_fluxd, FilterLookupError, UndefinedSourceError
 )
 from .. import data as sbd
-from ..spectroscopy.sources import SinglePointSpectrumError, SynphotRequired
-from ..exceptions import OptionalPackageUnavailable, SbpyWarning
+from ..spectroscopy.sources import SinglePointSpectrumError
+from ..exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable, SbpyWarning
 
 
 VEGA = u.def_unit(['VEGA', 'VEGAflux'],
@@ -152,7 +155,7 @@ def spectral_density_vega(wfb):
                 lambda f_phys, fluxd0=fluxd0.value: f_phys / fluxd0,
                 lambda f_vega, fluxd0=fluxd0.value: f_vega * fluxd0
             ))
-        except SynphotRequired:
+        except RequiredPackageUnavailable:
             warn(OptionalPackageUnavailable(
                 'synphot is required for Vega-based magnitude conversions'
                 ' with {}'.format(wfb)))

--- a/sbpy/units/tests/test_core.py
+++ b/sbpy/units/tests/test_core.py
@@ -130,7 +130,13 @@ def test_reflectance_ref(fluxd, wfb, f_sun, ref):
 
     pytest.importorskip("synphot")
 
-    wfb = bandpass(wfb) if type(wfb) is str else wfb
+    try:
+        # passes for "Johnson V", but fails for "V" band
+        # we will set "V" band to a specific value below
+        wfb = bandpass(wfb) if type(wfb) is str else wfb
+    except KeyError:
+        pass
+
     xsec = 6.648e5 * u.km**2
 
     with vega_fluxd.set({'V': u.Quantity(3.589e-9, 'erg/(s cm2 AA)')}):
@@ -162,7 +168,12 @@ def test_reflectance_xsec(fluxd, wfb, f_sun, radius):
 
     pytest.importorskip("synphot")
 
-    wfb = bandpass(wfb) if type(wfb) is str else wfb
+    try:
+        # passes for "Johnson V", but fails for "V" band
+        # we will set "V" band to a specific value below
+        wfb = bandpass(wfb) if type(wfb) is str else wfb
+    except KeyError:
+        pass
 
     ref = 0.02865984 / u.sr
     with vega_fluxd.set({'V': u.Quantity(3.589e-9, 'erg/(s cm2 AA)')}):

--- a/sbpy/units/tests/test_core.py
+++ b/sbpy/units/tests/test_core.py
@@ -5,16 +5,14 @@ import pytest
 import numpy as np
 import astropy.units as u
 from astropy.io import ascii
-from astropy.utils.data import get_pkg_data_filename
-import synphot
+from astropy.utils.data import get_pkg_data_path
+
 from .. import core
 from ..core import *
 from ...photometry import bandpass
 from ...calib import (vega_spectrum, vega_fluxd, solar_fluxd,
                       solar_spectrum, Sun, Vega)
-
-
-JohnsonV = bandpass('Johnson V')
+from ...exceptions import RequiredPackageUnavailable
 
 
 @pytest.mark.parametrize('unit,test', (
@@ -55,6 +53,9 @@ def test_spectral_density_vega_wf(wf, fluxd, to):
     Flux density at 5557.5 AA is from Bohlin 2014 (0.5% uncertainty).
 
     """
+
+    pytest.importorskip("synphot")
+
     v = fluxd.to(to.unit, spectral_density_vega(wf))
     assert v.unit == to.unit
     if to.unit in (VEGAmag, JMmag):
@@ -86,7 +87,10 @@ def test_spectral_density_vega_bp(filename, fluxd, to, tol):
     agreement with 0.03 mag.
 
     """
-    fn = get_pkg_data_filename(os.path.join(
+
+    synphot = pytest.importorskip("synphot")
+
+    fn = get_pkg_data_path(os.path.join(
         '..', '..', 'photometry', 'data', filename))
     bp = synphot.SpectralElement.from_file(fn)
 
@@ -98,19 +102,14 @@ def test_spectral_density_vega_bp(filename, fluxd, to, tol):
         assert np.isclose(v.value, to.value, rtol=tol)
 
 
-def test_spectral_density_vega_synphot_import_fail(monkeypatch):
-    from ...calib import core as calib_core
-    monkeypatch.setattr(calib_core, 'synphot', None)
-    assert spectral_density_vega([1, 2, 3] * u.um) == []
-
-
 def test_spectral_density_vega_undefinedsourceerror():
+    pytest.importorskip("synphot")
     with vega_spectrum.set(Vega(None)):
         assert spectral_density_vega([1, 2, 3] * u.um) == []
 
 
 @pytest.mark.parametrize('fluxd, wfb, f_sun, ref', (
-    (3.4 * VEGAmag, JohnsonV, None, 0.02865984),
+    (3.4 * VEGAmag, "Johnson V", None, 0.02865984),
     (3.4 * VEGAmag, 5500 * u.AA, None, 0.02774623),
     (1.56644783e-09 * u.Unit('W/(m2 um)'), 'V',
         1839.93273227 * u.Unit('W/(m2 um)'), 0.02865984),
@@ -129,6 +128,9 @@ def test_reflectance_ref(fluxd, wfb, f_sun, ref):
 
     """
 
+    pytest.importorskip("synphot")
+    
+    wfb = bandpass(wfb) if type(wfb) is str else wfb
     xsec = 6.648e5 * u.km**2
 
     with vega_fluxd.set({'V': u.Quantity(3.589e-9, 'erg/(s cm2 AA)')}):
@@ -139,7 +141,7 @@ def test_reflectance_ref(fluxd, wfb, f_sun, ref):
 
 
 @pytest.mark.parametrize('fluxd, wfb, f_sun, radius', (
-    (3.4 * VEGAmag, JohnsonV, None, 460.01351274),
+    (3.4 * VEGAmag, "Johnson V", None, 460.01351274),
     (3.4 * VEGAmag, 5500 * u.AA, None, 452.62198065),
     (1.56644783e-09 * u.Unit('W/(m2 um)'), 'V',
         1839.93273227 * u.Unit('W/(m2 um)'), 460.01351274),
@@ -157,6 +159,10 @@ def test_reflectance_xsec(fluxd, wfb, f_sun, radius):
     albedo 0.09).
 
     """
+
+    pytest.importorskip("synphot")
+
+    wfb = bandpass(wfb) if type(wfb) is str else wfb
 
     ref = 0.02865984 / u.sr
     with vega_fluxd.set({'V': u.Quantity(3.589e-9, 'erg/(s cm2 AA)')}):
@@ -179,12 +185,14 @@ def test_reflectance_spec():
     'data/hi05070405_9000036-avg-spec.txt', data from McLaughlin et al (2014).
     """
 
+    pytest.importorskip("synphot")
+
     ifov = 1e-5 * u.rad
     delta = 15828 * u.km
     rh = 1.5 * u.au
 
     # Tempel 1 spectrum, includes reference solar spectrum
-    fn = get_pkg_data_filename(
+    fn = get_pkg_data_path(
         os.path.join('data', 'hi05070405_9000036-avg-spec.txt'))
     t1 = ascii.read(fn)
     sun = Sun.from_array(t1['wave'] * u.um,

--- a/sbpy/units/tests/test_core.py
+++ b/sbpy/units/tests/test_core.py
@@ -129,7 +129,7 @@ def test_reflectance_ref(fluxd, wfb, f_sun, ref):
     """
 
     pytest.importorskip("synphot")
-    
+
     wfb = bandpass(wfb) if type(wfb) is str else wfb
     xsec = 6.648e5 * u.km**2
 

--- a/sbpy/utils/__init__.py
+++ b/sbpy/utils/__init__.py
@@ -2,5 +2,5 @@
 
 """For common non-sub-module specific utility functions."""
 
-from . import decorators
 from .core import *
+from . import decorators

--- a/sbpy/utils/__init__.py
+++ b/sbpy/utils/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-# This sub-module is destined for common non-package specific utility
-# functions.
+"""For common non-sub-module specific utility functions."""
 
+from . import decorators
 from .core import *

--- a/sbpy/utils/core.py
+++ b/sbpy/utils/core.py
@@ -6,15 +6,16 @@ created on March 12, 2019
 
 """
 
-__all__ = ["requires", "optional"]
+__all__ = ["required_packages", "optional_packages"]
 
 from importlib import import_module
 from warnings import warn
 from ..exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
 
 
-def requires(*packages, message=None):
+def required_packages(*packages, message=None):
     """Verifies the arguments are valid packages.
+
 
     Parameters
     ----------
@@ -34,8 +35,8 @@ def requires(*packages, message=None):
     Examples
     --------
 
-    >>> from sbpy.utils import requires
-    >>> requires("unavailable_package")
+    >>> from sbpy.utils import required_packages
+    >>> required_packages("unavailable_package")
     Traceback (most recent call last):
     ...
     sbpy.exceptions.RequiredPackageUnavailable: `unavailable_package` is required.
@@ -47,11 +48,13 @@ def requires(*packages, message=None):
             import_module(package)
         except ModuleNotFoundError as exc:
             _message = "" if message is None else "  " + message
-            raise RequiredPackageUnavailable(f"`{package}` is required.{_message}") from None
+            raise RequiredPackageUnavailable(
+                f"`{package}` is required.{_message}") from None
 
 
-def optional(*packages, message=None):
+def optional_packages(*packages, message=None):
     """Decorator that warns if the arguments are not valid packages.
+
 
     Parameters
     ----------
@@ -78,8 +81,8 @@ def optional(*packages, message=None):
     Examples
     --------
 
-    >>> from sbpy.utils import optional
-    >>> optional("unavailable_package")  # doctest: +SKIP
+    >>> from sbpy.utils import optional_packages
+    >>> optional_packages("unavailable_package")  # doctest: +SKIP
     OptionalPackageUnavailable: Optional package `unavailable_package` is unavailable.
 
     """

--- a/sbpy/utils/core.py
+++ b/sbpy/utils/core.py
@@ -6,4 +6,93 @@ created on March 12, 2019
 
 """
 
-__all__ = []
+__all__ = ["requires", "optional"]
+
+from importlib import import_module
+from warnings import warn
+from ..exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
+
+
+def requires(*packages, message=None):
+    """Verifies the arguments are valid packages.
+
+    Parameters
+    ----------
+    *modules : str
+        The names of packages to test.
+
+    message : str
+        An additional message to show the user, e.g., the reason for the
+        requirement.
+
+    Raises
+    ------
+
+    `~sbpy.exceptions.RequiredPackageUnavailable`
+
+
+    Examples
+    --------
+
+    >>> from sbpy.utils import requires
+    >>> requires("unavailable_package")
+    Traceback (most recent call last):
+    ...
+    sbpy.exceptions.RequiredPackageUnavailable: `unavailable_package` is required.
+
+    """
+
+    for package in packages:
+        try:
+            import_module(package)
+        except ModuleNotFoundError as exc:
+            _message = "" if message is None else "  " + message
+            raise RequiredPackageUnavailable(f"`{package}` is required.{_message}") from None
+
+
+def optional(*packages, message=None):
+    """Decorator that warns if the arguments are not valid packages.
+
+    Parameters
+    ----------
+    *modules : str
+        The names of packages to test.
+
+    message : str
+        An additional note to show the user, e.g., a description of the fallback
+        behavior.
+
+
+    Returns
+    -------
+    success : bool
+        ``True`` if all optional packages are available.
+
+
+    Warnings
+    --------
+
+    `~sbpy.exceptions.OptionalPackageUnavailable`
+
+
+    Examples
+    --------
+
+    >>> from sbpy.utils import optional
+    >>> optional("unavailable_package")  # doctest: +SKIP
+    OptionalPackageUnavailable: Optional package `unavailable_package` is unavailable.
+
+    """
+    # the doctest line is skipped to avoid polluting the testing suite with a warning
+
+    for package in packages:
+        try:
+            import_module(package)
+        except ModuleNotFoundError:
+            _message = "" if message is None else "  " + message
+            warn(
+                f"`{package}`.{_message}",
+                OptionalPackageUnavailable,
+            )
+            return False
+    return True

--- a/sbpy/utils/decorators.py
+++ b/sbpy/utils/decorators.py
@@ -2,8 +2,11 @@
 
 """Common sbpy method/function decorators."""
 
+__all__ = ["requires", "optional"]
+
+from warnings import warn
 from functools import wraps
-from ..exceptions import RequiredPackageUnavailable
+from ..exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
 
 def requires(*packages):
     """Decorator that verifies the arguments are valid packages.
@@ -23,21 +26,14 @@ def requires(*packages):
     Examples
     --------
 
-    >>> try:
-    ...     import unavailable_package
-    ... except ImportError:
-    ...     unavailable_package = None
-    >>>
     >>> from sbpy.utils.decorators import requires
-    >>>
-    >>> @requires(unavailable_package=unavailable_package)
+    >>> @requires("unavailable_package")
     ... def f():
     ...     pass
-    >>>
     >>> f()
     Traceback (most recent call last):
     ...
-    sbpy.exceptions.RequiredPackageUnavailable: unavailable_package is required for f.
+    sbpy.exceptions.RequiredPackageUnavailable: unavailable_package is required for sbpy.utils.decorators.f.
 
     """
 
@@ -53,6 +49,60 @@ def requires(*packages):
                     raise RequiredPackageUnavailable(
                         f"{package} is required for {function_name}."
                     )
+            return wrapped_function(*func_args, **func_kwargs)
+        
+        return wrapper
+
+    return decorator
+
+
+def optional(*packages, note=None):
+    """Decorator that warns if the arguments are not valid packages.
+
+    Parameters
+    ----------
+    *modules : str
+        The names of packages to test.
+
+    note : str
+        An additional note to show the user, e.g., a description of the fallback
+        behavior.
+
+
+    Warnings
+    --------
+
+    `~sbpy.exceptions.OptionalPackageUnavailable`
+
+
+    Examples
+    --------
+
+    >>> from sbpy.utils.decorators import requires
+    >>> @optional("unavailable_package")
+    ... def f():
+    ...     pass
+    >>> f()  # doctest: +IGNORE_OUTPUT
+    sbpy/utils/decorators.py::sbpy.utils.decorators.optional
+    ...
+    OptionalPackageUnavailable: Optional package unavailable_package is not available for sbpy.utils.decorators.f.
+
+    """
+
+    def decorator(wrapped_function):
+        @wraps(wrapped_function)
+        def wrapper(*func_args, **func_kwargs):
+            for package in packages:
+                try:
+                    __import__(package)
+                except ImportError:
+                    function_name = '.'.join((wrapped_function.__module__,
+                                              wrapped_function.__qualname__))
+                    warn(OptionalPackageUnavailable(
+                        f"Optional package {package} is not available "
+                        f"for {function_name}."
+                        + ("" if note is None else note)
+                    ))
             return wrapped_function(*func_args, **func_kwargs)
         
         return wrapper

--- a/sbpy/utils/decorators.py
+++ b/sbpy/utils/decorators.py
@@ -1,0 +1,60 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""Common sbpy method/function decorators."""
+
+from functools import wraps
+from ..exceptions import RequiredPackageUnavailable
+
+def requires(*packages):
+    """Decorator that verifies the arguments are valid packages.
+
+    Parameters
+    ----------
+    *modules : str
+        The names of packages to test.
+
+
+    Raises
+    ------
+
+    `~sbpy.exceptions.RequiredPackageUnavailable`
+
+
+    Examples
+    --------
+
+    >>> try:
+    ...     import unavailable_package
+    ... except ImportError:
+    ...     unavailable_package = None
+    >>>
+    >>> from sbpy.utils.decorators import requires
+    >>>
+    >>> @requires(unavailable_package=unavailable_package)
+    ... def f():
+    ...     pass
+    >>>
+    >>> f()
+    Traceback (most recent call last):
+    ...
+    sbpy.exceptions.RequiredPackageUnavailable: unavailable_package is required for f.
+
+    """
+
+    def decorator(wrapped_function):
+        @wraps(wrapped_function)
+        def wrapper(*func_args, **func_kwargs):
+            for package in packages:
+                try:
+                    __import__(package)
+                except ImportError:
+                    function_name = '.'.join((wrapped_function.__module__,
+                                              wrapped_function.__qualname__))
+                    raise RequiredPackageUnavailable(
+                        f"{package} is required for {function_name}."
+                    )
+            return wrapped_function(*func_args, **func_kwargs)
+        
+        return wrapper
+
+    return decorator

--- a/sbpy/utils/decorators.py
+++ b/sbpy/utils/decorators.py
@@ -2,7 +2,7 @@
 
 """Common sbpy method/function decorators."""
 
-__all__ = ["requires", "optional"]
+__all__ = ["requires", "optionally_uses"]
 
 from functools import wraps
 from . import core
@@ -12,9 +12,10 @@ from ..exceptions import RequiredPackageUnavailable
 def requires(*packages, message=None):
     """Decorator that verifies the arguments are valid packages.
 
+
     Parameters
     ----------
-    *modules : str
+    *packages : str
         The names of packages to test.
 
 
@@ -42,12 +43,13 @@ def requires(*packages, message=None):
         function_name = ".".join(
             (wrapped_function.__module__, wrapped_function.__qualname__)
         )
-        _message = ("" if message is None else f"{message} ") + f"({function_name})"
+        _message = (
+            "" if message is None else f"{message} ") + f"({function_name})"
 
         @wraps(wrapped_function)
         def wrapper(*func_args, **func_kwargs):
             try:
-                core.requires(*packages, message=_message)
+                core.required_packages(*packages, message=_message)
             except RequiredPackageUnavailable as exc:
                 # trim a couple levels of the traceback to clean up error messages
                 raise exc.with_traceback(exc.__traceback__.tb_next.tb_next)
@@ -58,12 +60,13 @@ def requires(*packages, message=None):
     return decorator
 
 
-def optional(*packages, message=None):
-    """Decorator that warns if the arguments are not valid packages.
+def optionally_uses(*packages, message=None):
+    """Decorator that warns if the arguments are not valid modules.
+
 
     Parameters
     ----------
-    *modules : str
+    *packages : str
         The names of packages to test.
 
     message : str
@@ -80,8 +83,8 @@ def optional(*packages, message=None):
     Examples
     --------
 
-    >>> from sbpy.utils.decorators import requires
-    >>> @optional("unavailable_package")
+    >>> from sbpy.utils.decorators import optionally_uses
+    >>> @optionally_uses("unavailable_package")
     ... def f():
     ...     pass
     >>> f()  # doctest: +SKIP
@@ -96,11 +99,12 @@ def optional(*packages, message=None):
         function_name = ".".join(
             (wrapped_function.__module__, wrapped_function.__qualname__)
         )
-        _message = ("" if message is None else f"{message} ") + f"({function_name})"
+        _message = (
+            "" if message is None else f"{message} ") + f"({function_name})"
 
         @wraps(wrapped_function)
         def wrapper(*func_args, **func_kwargs):
-            core.optional(*packages, message=_message)
+            core.optional_packages(*packages, message=_message)
             return wrapped_function(*func_args, **func_kwargs)
 
         return wrapper

--- a/sbpy/utils/tests/test_core.py
+++ b/sbpy/utils/tests/test_core.py
@@ -1,29 +1,29 @@
 import pytest
-from ..core import requires, optional
+from ..core import required_packages, optional_packages
 from ...exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
 
 
 def test_requires():
     with pytest.raises(RequiredPackageUnavailable):
-        requires("unavailable_package")
+        required_packages("unavailable_package")
 
 
 def test_requires_message():
     try:
         message = "Because these integrations are tricky."
-        requires("unavailable_package", message=message)
+        required_packages("unavailable_package", message=message)
     except RequiredPackageUnavailable as exc:
         assert message in str(exc)
 
 
 def test_optional():
     with pytest.warns(OptionalPackageUnavailable):
-        assert not optional("unavailable_package")
+        assert not optional_packages("unavailable_package")
 
-    assert optional("astropy")
+    assert optional_packages("astropy")
 
 
 def test_optional_message():
     message = "Using linear interpolation."
     with pytest.warns(OptionalPackageUnavailable, match=message) as record:
-        optional("unavailable_package", message=message)
+        optional_packages("unavailable_package", message=message)

--- a/sbpy/utils/tests/test_core.py
+++ b/sbpy/utils/tests/test_core.py
@@ -1,0 +1,29 @@
+import pytest
+from ..core import requires, optional
+from ...exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
+
+
+def test_requires():
+    with pytest.raises(RequiredPackageUnavailable):
+        requires("unavailable_package")
+
+
+def test_requires_message():
+    try:
+        message = "Because these integrations are tricky."
+        requires("unavailable_package", message=message)
+    except RequiredPackageUnavailable as exc:
+        assert message in str(exc)
+
+
+def test_optional():
+    with pytest.warns(OptionalPackageUnavailable):
+        assert not optional("unavailable_package")
+
+    assert optional("astropy")
+
+
+def test_optional_message():
+    message = "Using linear interpolation."
+    with pytest.warns(OptionalPackageUnavailable, match=message) as record:
+        optional("unavailable_package", message=message)

--- a/sbpy/utils/tests/test_decorators.py
+++ b/sbpy/utils/tests/test_decorators.py
@@ -1,22 +1,24 @@
 from warnings import catch_warnings
 import pytest
-from ..decorators import requires, optional
+from ..decorators import requires, optionally_uses
 from ...exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
 
 
-def test_requires():
-    @requires("unavailable_package")
-    def f():
-        pass
+@requires("unavailable_package")
+def f_required():
+    pass
 
+
+@optionally_uses("unavailable_package")
+def f_optional():
+    pass
+
+
+def test_requires():
     with pytest.raises(RequiredPackageUnavailable):
-        f()
+        f_required()
 
 
 def test_optional():
-    @optional("unavailable_package")
-    def f():
-        pass
-
     with pytest.warns(OptionalPackageUnavailable):
-        f()
+        f_optional()

--- a/sbpy/utils/tests/test_decorators.py
+++ b/sbpy/utils/tests/test_decorators.py
@@ -1,0 +1,20 @@
+from warnings import catch_warnings
+import pytest
+from ..decorators import requires, optional
+from ...exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
+
+def test_requires():
+    @requires("unavailable_package")
+    def f():
+        pass
+
+    with pytest.raises(RequiredPackageUnavailable):
+        f()
+
+def test_optional():
+    @optional("unavailable_package")
+    def f():
+        pass
+
+    with pytest.warns(OptionalPackageUnavailable):
+        f()

--- a/sbpy/utils/tests/test_decorators.py
+++ b/sbpy/utils/tests/test_decorators.py
@@ -3,6 +3,7 @@ import pytest
 from ..decorators import requires, optional
 from ...exceptions import RequiredPackageUnavailable, OptionalPackageUnavailable
 
+
 def test_requires():
     @requires("unavailable_package")
     def f():
@@ -10,6 +11,7 @@ def test_requires():
 
     with pytest.raises(RequiredPackageUnavailable):
         f()
+
 
 def test_optional():
     @optional("unavailable_package")

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,21 +27,27 @@ packages = find:
 zip_save = False
 python_requires = >=3.8
 setup_requires = setuptools_scm
+
 # keep requirements in synchronization with docs/install.rst
 install_requires =
     numpy>=1.18.0
     astropy>=4.3
-    ads>=0.12
-    synphot>=1.1.1
-    astroquery>=0.4.5
 include_package_data = True
 
 [options.extras_require]
-all =
+recommended =
+    ads>=0.12
+    astroquery>=0.4.5
     scipy>=1.3
+    synphot>=1.1.1
+all =
+    ads>=0.12
+    astroquery>=0.4.5
     ginga
     photutils
     pyyaml
+    scipy>=1.3
+    synphot>=1.1.1
 test =
     pytest>=7.0
     pytest-astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,18 @@ filterwarnings =
     ignore:numpy\.ufunc size changed:RuntimeWarning
     ignore:numpy\.ndarray size changed:RuntimeWarning
 
+# The following is to work around an issue building the documentation (see
+# #383).  The prefered approach is to use doctest-requires at the code-block
+# level (e.g., this marks all orbit.rst tests as needed oorb, but only 2 of 9
+# blocks require it).  Relevant doctest-requires directives have been commented
+# out.
+doctest_subpackage_requires =
+    docs/sbpy/photometry.rst = astroquery
+    docs/sbpy/data/ephem.rst = astroquery
+    docs/sbpy/data/obs.rst = astroquery
+    docs/sbpy/data/orbit.rst = astroquery,oorb
+    docs/sbpy/data/phys.rst = astroquery
+
 # [coverage:run]
 # omit =
 #     sbpy/_astropy_init*

--- a/tox.ini
+++ b/tox.ini
@@ -92,7 +92,9 @@ commands =
 [testenv:build_docs]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
-extras = docs
+extras =
+    docs
+    all
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html


### PR DESCRIPTION
Make scipy, ads, astroquery, and synphot optional packages, limiting the required packages to numpy and astropy.

* Add new functions and decorators in utils to facilitate testing for optional packages, and raising errors when they are needed.
* Skip tests that require the above packages when they are not available.

To do:
- [x] Verify that tests are working when the above packages are installed (i.e., alldeps).
- [ ] ~Update documentation so that it can be built without optional packages?~


Addresses #382 