### PR TITLE
Mark slow tests

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -6,14 +6,14 @@ name: Weekly CI Tests
 on:
   schedule:
     # run at 5am UTC on Mondays
-    - cron: '0 5 * * 1'
+    - cron: "0 5 * * 1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  IS_CRON: 'true'
+  IS_CRON: "true"
 
 jobs:
   tests:
@@ -24,26 +24,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Check links in docs using tox
-          toxenv: linkcheck
-        - name: Check dev versions of key dependencies
-          python: '3.11'
-          toxenv: py311-test-devdeps
-          toxposargs: --remote-data
+          - name: Check links in docs using tox
+            toxenv: linkcheck
+          - name: Check dev versions of key dependencies
+            python: "3.11"
+            toxenv: py311-test-devdeps
+            toxposargs: --remote-data --run-slow
+            posargs: --durations=50
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python }}
-    - name: Install base dependencies
-      run: |
-        python -m pip install --upgrade pip tox
-    - name: Run tests
-      env:
-        ADS_DEV_KEY: ${{ secrets.ADS_DEV_KEY }}
-      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip tox
+      - name: Run tests
+        env:
+          ADS_DEV_KEY: ${{ secrets.ADS_DEV_KEY }}
+        run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -48,7 +48,7 @@ jobs:
           toxargs: -v
           posargs: -n=4 --run-slow
 
-          - name: Python 3.8 with oldest supported versions
+        - name: Python 3.8 with oldest supported versions
           linux: py38-test-oldestdeps
           coverage: codecov
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -7,9 +7,9 @@ name: CI Tests
 on:
   push:
     branches:
-    - main
+      - main
     tags:
-    - '*'
+      - "*"
   pull_request:
     # branches: # only build on PRs against 'main' if you need to further limit when CI is run.
     #    - main
@@ -34,7 +34,7 @@ jobs:
         ARCH_ON_CI: "normal"
         IS_CRON: "false"
       submodules: false
-      coverage: ''
+      coverage: ""
       envs: |
         - name: Code style checks
           linux: codestyle
@@ -43,10 +43,12 @@ jobs:
           linux: py311-test-cov
           coverage: codecov
 
-        - name: Python 3.10 with all optional dependencies
+        - name: Python 3.10 in parallel with all optional dependencies and slow tests
           linux: py310-test-alldeps
-          
-        - name: Python 3.8 with oldest supported versions
+          toxargs: -v
+          posargs: -n=4 --run-slow
+
+          - name: Python 3.8 with oldest supported versions
           linux: py38-test-oldestdeps
           coverage: codecov
 
@@ -56,23 +58,23 @@ jobs:
     env:
       ARCH_ON_CI: "normal"
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Set up python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-    - name: Set up gfortran on ${{ matrix.os }}
-      if: runner.os == 'macos'
-      run: |
-        echo `which gfortran-11`
-        sudo ln -sfn /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
-        gfortran --version
-    - name: Install base dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Test with tox
-      run: tox -e py310-test-alldeps
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Set up gfortran on ${{ matrix.os }}
+        if: runner.os == 'macos'
+        run: |
+          echo `which gfortran-11`
+          sudo ln -sfn /usr/local/bin/gfortran-11 /usr/local/bin/gfortran
+          gfortran --version
+      - name: Install base dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
+      - name: Test with tox
+        run: tox -e py310-test-alldeps

--- a/sbpy/activity/gas/tests/test_core.py
+++ b/sbpy/activity/gas/tests/test_core.py
@@ -421,6 +421,7 @@ class TestVectorialModel:
             coma.vmr.num_fragments_grid, num_fragments_grid, rtol=0.02
         )
 
+    @pytest.mark.slow
     def test_time_dependent_function(self):
         """
         Test handing off a time dependence to the model with zero additional
@@ -463,6 +464,7 @@ class TestVectorialModel:
             coma_steady.vmr.num_fragments_grid, coma_q_t.vmr.num_fragments_grid, rtol=0.02
         )
 
+    @pytest.mark.slow
     def test_binned_production_one_element_list(self):
         """
         Initialize a comet with the fortran-version style of specifying time
@@ -506,6 +508,7 @@ class TestVectorialModel:
             coma_steady.vmr.num_fragments_grid, coma_binned.vmr.num_fragments_grid, rtol=0.02
         )
 
+    @pytest.mark.slow
     def test_binned_production_multi_element_list(self):
         """
         Initialize a comet with the fortran-version style of specifying time
@@ -604,6 +607,7 @@ class TestVectorialModel:
             coma.vmr.num_fragments_theory, coma.total_number(ap), rtol=0.02
         )
 
+    @pytest.mark.slow
     def test_model_symmetry(self):
         """
         The symmetry of the model allows the parent production to be
@@ -681,6 +685,7 @@ class TestVectorialModel:
             [1.3366, 0.8720, 560e-14, 4.03e-4, 2.035e28],
         ),
     )
+    @pytest.mark.slow
     def test_festou92(self, rh, delta, flux, g, Q):
         """Compare to Festou et al. 1992 production rates of comet 6P/d'Arrest.
 
@@ -755,6 +760,7 @@ class TestVectorialModel:
             [2.0715, 1.7930, 1.01e32, 1.88e29],
         ),
     )
+    @pytest.mark.slow
     def test_combi93(self, rh, delta, N, Q):
         """Compare to results of Combi et al. 1993.
 
@@ -794,6 +800,7 @@ class TestVectorialModel:
         Q_model = (Q0 * N / N0).to(Q.unit)
         assert u.allclose(Q, Q_model, rtol=0.13)
 
+    @pytest.mark.slow
     def test_vm_fortran(self):
         """Compare to results from vm.f.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ all =
     pyyaml
 test =
     pytest>=7.0
-    pytest-astropy
+    pytest-astropy>=0.10
     pytest-doctestplus>=0.10
     pytest-remotedata
     pytest-xdist


### PR DESCRIPTION
Mark the slowest tests as "slow" and only run them on CI once.  Also enable parallel execution on the testing environment that runs alldeps and the slow tests.

This PR requires pytest-astropy>=0.10, which supports the use of pytest.mark.slow.
