### PR TITLE
Add missing references to calspec solar spectrum.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ Bug Fixes
   ``RequiredPackageUnavailable`` when ``synphot`` is not available, replacing a
   locally defined ``SynphotRequired`` or the generic ``ImportError``.
 
+sbpy.calib
+^^^^^^^^^^
+* Fixed: the CALSPEC solar spectrum was missing from `solar_sources`. [#387]
+
 
 0.4.0 (2023-06-30)
 ==================

--- a/sbpy/calib/__init__.py
+++ b/sbpy/calib/__init__.py
@@ -18,6 +18,7 @@ are downloaded and cached as needed::
   E490_2014LR - Low resolution version of E490 (ASTM 2014).
   Kurucz1993 - Kurucz (1993) model scaled by Colina et al. (1996).
   Castelli1996 - Catelli model spectrum from Colina et al. (1996).
+  calspec - STSCI CALSPEC R~5000 model solar spectrum, Bohlin et al. (2014).
 
 Filter photometry from Willmer (2018).
 

--- a/sbpy/calib/solar_sources.py
+++ b/sbpy/calib/solar_sources.py
@@ -15,7 +15,8 @@ sources = [
     'E490_2014',
     'E490_2014LR',
     'Kurucz1993',
-    'Castelli1996'
+    'Castelli1996',
+    'calspec',
 ]
 
 


### PR DESCRIPTION
Update `calib` docstring and `calib.solar_sources.sources` to include calspec spectrum.  Documentation (`docs/sbpy/calib.rst`) is already up to date.

