### PR TITLE
Remove system_packages from readthedocs config.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,6 @@ sphinx:
   fail_on_warning: true
 
 python:
-  system_packages: true
   install:
     - method: pip
       path: .


### PR DESCRIPTION
This is a mandatory change since 2023 Sep 25: https://blog.readthedocs.com/migrate-configuration-v2/