### PR TITLE
Initialize CircularAperture from other apertures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,15 +13,19 @@
 New Features
 ------------
 
+sbpy.activity
+^^^^^^^^^^^^^
+- New `sbpy.activity.CircularAperture.from_coma_equivalent()` to immediately
+  create a `CircularAperture` from any other `Aperture` given a nominal coma
+  surface brightness distribution. [#393]
+
 sbpy.utils
 ^^^^^^^^^^
-
 - New `required_packages` and `optional_packages` functions to test for the
   presence of required and optional packages.
 
 sbpy.utils.decorators
 ^^^^^^^^^^^^^^^^^^^^^
-
 - New `requires` and  `optionally_uses` function decorators to simplify testing
   for required and optional packages.
 

--- a/docs/sbpy/activity/index.rst
+++ b/docs/sbpy/activity/index.rst
@@ -16,7 +16,7 @@ Introduction
 Apertures
 ---------
 
-Four photometric apertures are defined:
+Four photometric aperture classes are defined, primarily for use with cometary comae:
 
   * `~sbpy.activity.CircularAperture`: a circle,
   * `~sbpy.activity.AnnularAperture`: an annulus,
@@ -48,6 +48,10 @@ Ideal comae (constant production rate, free-expansion, infinite lifetime) have *
   >>> sba.CircularAperture(ap.coma_equivalent_radius())  # doctest: +FLOAT_CMP
   <CircularAperture: radius 1669.4204086589311 km>
 
+Through the ``coma_equivalent_radius()`` method, all apertures may be used to initialize a ``CircularAperture`` instance using the :func:`~sbpy.activity.CircularAperture.from_coma_equivalent` method:
+
+  >>> sba.CircularAperture.from_coma_equivalent(ap)
+  <CircularAperture: radius 1669.4204086589311 km>
 
 Reference/API
 -------------

--- a/sbpy/activity/core.py
+++ b/sbpy/activity/core.py
@@ -134,6 +134,25 @@ class CircularAperture(Aperture):
         return self.radius
     coma_equivalent_radius.__doc__ = Aperture.coma_equivalent_radius.__doc__
 
+    @classmethod
+    def from_coma_equivalent(cls, aperture):
+        """Initialize based on coma equivalent radius.
+
+
+        Parameters
+        ----------
+        aperture : `Aperture` or `~sbpy.units.Quantity`
+            Another aperture or a radius.
+
+        """
+
+        if isinstance(aperture, Aperture):
+            radius = aperture.coma_equivalent_radius()
+        else:
+            radius = u.Quantity(aperture)
+
+        return cls(radius)
+
 
 class AnnularAperture(Aperture):
     """Annular aperture projected at the distance of the target.

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -32,7 +32,7 @@ from ..utils import optional_packages
 from .. import data as sbd
 from .. import units as sbu
 from ..spectroscopy.sources import SinglePointSpectrumError
-from .core import Aperture
+from .core import CircularAperture
 
 
 @bib.cite(
@@ -337,8 +337,7 @@ class DustComaQuantity(u.SpecificTypeQuantity, metaclass=abc.ABCMeta):
 
         """
 
-        fluxd1cm = cls(1 * u.cm).to_fluxd(wfb, aper,
-                                          eph, unit=fluxd.unit, **kwargs)
+        fluxd1cm = cls(1 * u.cm).to_fluxd(wfb, aper, eph, unit=fluxd.unit, **kwargs)
 
         if isinstance(fluxd1cm, u.Magnitude):
             coma = cls((fluxd - fluxd1cm).physical * u.cm)
@@ -380,12 +379,8 @@ class DustComaQuantity(u.SpecificTypeQuantity, metaclass=abc.ABCMeta):
         # rho = effective circular aperture radius at the distance of
         # the comet.  Keep track of array dimensionality as Ephem
         # objects can needlessly increase the number of dimensions.
-        if isinstance(aper, Aperture):
-            rho = aper.coma_equivalent_radius()
-            ndim = np.ndim(rho)
-        else:
-            rho = aper
-            ndim = np.ndim(rho)
+        rho = CircularAperture.from_coma_equivalent(aper)
+        ndim = np.ndim(rho)
         rho = rho.to("km", sbu.projected_size(eph))
 
         ndim = max(ndim, np.ndim(self))

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -337,7 +337,13 @@ class DustComaQuantity(u.SpecificTypeQuantity, metaclass=abc.ABCMeta):
 
         """
 
-        fluxd1cm = cls(1 * u.cm).to_fluxd(wfb, aper, eph, unit=fluxd.unit, **kwargs)
+        fluxd1cm = cls(1 * u.cm).to_fluxd(
+            wfb,
+            aper,
+            eph,
+            unit=fluxd.unit,
+            **kwargs,
+        )
 
         if isinstance(fluxd1cm, u.Magnitude):
             coma = cls((fluxd - fluxd1cm).physical * u.cm)

--- a/sbpy/activity/dust.py
+++ b/sbpy/activity/dust.py
@@ -379,7 +379,7 @@ class DustComaQuantity(u.SpecificTypeQuantity, metaclass=abc.ABCMeta):
         # rho = effective circular aperture radius at the distance of
         # the comet.  Keep track of array dimensionality as Ephem
         # objects can needlessly increase the number of dimensions.
-        rho = CircularAperture.from_coma_equivalent(aper)
+        rho = CircularAperture.from_coma_equivalent(aper).dim
         ndim = np.ndim(rho)
         rho = rho.to("km", sbu.projected_size(eph))
 

--- a/sbpy/activity/tests/test_core.py
+++ b/sbpy/activity/tests/test_core.py
@@ -35,6 +35,17 @@ class TestCircularAperture:
         angle = r.to('arcsec', sbu.projected_size(eph))
         assert np.isclose(aper.as_angle(eph).dim.value, angle.value)
 
+    def test_from_coma_equivalent(self):
+        # test initialization from another aperture
+        shape = [1, 2] * u.arcsec
+        an_aper = AnnularAperture(shape)
+        circ_aper = CircularAperture.from_coma_equivalent(an_aper)
+        assert circ_aper.dim == 1 * u.arcsec
+
+        # test initialization from a radius
+        circ_aper = CircularAperture.from_coma_equivalent(1 * u.arcsec)
+        assert circ_aper.dim == 1 * u.arcsec
+
 
 class TestAnnularAperture:
     def test_str(self):


### PR DESCRIPTION
The `Afrho` and `Efrho` classes can take a `Quantity` or an `Aperture` as an input for the photometric aperture radius, and they will convert it to a coma equivalent radius, as needed.  While writing new code for PR #376, I needed to repeat that same Quantity/Aperture conversion code, and also repeat tests for each case.  This seemed like an opportunity for an enhancement that could simplify the code.

Each of the `Aperture` classes can be converted to an effective circular aperture based on the assumption of a 1/rho coma.  This PR enables any of the `Aperture` classes to directly initialize a `CircularAperture` object using that coma equivalent aperture conversion:
```python
>>> import astropy.units as u
>>> from sbpy.activity import CircularAperture, RectangularAperture
>>>
>>> rect = RectangularAperture([1, 5] * u.arcsec)
>>> circ = CircularAperture.from_coma_equivalent(rect)
>>> print(circ)
Circular aperture, radius 1.0522971172731228 arcsec
```

Or, a radius may be given as a `Quantity`, in which case the "coma equivalent" radius is the same value:
```python
>>> circ = CircularAperture.from_coma_equivalent(10 * u.arcsec)
>>> print(circ)
Circular aperture, radius 10.0 arcsec
```

With this change, the `Afrho`, `Efrho`, and any similar code that needs the effective aperture radius for a 1/rho coma can pass their input parameters to `CircularAperture` without the need to test for `Quantity` vs. `Aperture` input, and the developers do not need to be concerned with the conversions for testing coverage:

```python
# works for aper as Quantity or Aperture:
rho = CircularAperture.from_coma_equivalent(aper).dim
```

