### PR TITLE
Configure pep8speaks to use 88 character line length

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,2 @@
+pycodestyle:
+  max-line-length: 88


### PR DESCRIPTION
I'm happy with black formatting, which uses an 88 character line length limit.  Astropy has also moved to formatting code with black.  Shall we change pep8speaks to use an 88 character limit?  (see #394 for an example with 80 character line length but code formatted with black).

