### PR TITLE
Linkcheck is missing synphot

### DIFF
--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -29,7 +29,7 @@ jobs:
         - name: Check dev versions of key dependencies
           python: '3.11'
           toxenv: py311-test-devdeps
-          toxposargs: --remote-data --keep-going
+          toxposargs: --remote-data
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci_cron_weekly.yml
+++ b/.github/workflows/ci_cron_weekly.yml
@@ -29,7 +29,7 @@ jobs:
         - name: Check dev versions of key dependencies
           python: '3.11'
           toxenv: py311-test-devdeps
-          toxposargs: --remote-data
+          toxposargs: --remote-data --keep-going
 
     steps:
     - name: Checkout code

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ test =
     pytest-xdist
     coverage
 docs =
-    pytest>=7.0
+    sbpy[all,test]
     matplotlib>=3.1
     sphinx-astropy>=1.3,!=1.9.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -94,9 +94,7 @@ commands =
 [testenv:build_docs]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
-extras =
-    docs
-    all
+extras = docs
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -105,7 +105,7 @@ description = check the links in the HTML docs
 extras = docs
 commands =
     pip freeze
-    sphinx-build -W -b linkcheck . _build/html
+    sphinx-build -W -b linkcheck . _build/html --keep-going
 
 [testenv:codestyle]
 # We list the warnings/errors to check for here rather than in setup.cfg because


### PR DESCRIPTION
Edit the requirements for building the documentation and for linkchecks to use all recommended and testing packages.  This addresses the linkcheck error (missing synphot) in this week's tests.  Also, when running linkcheck, don't stop at the first error.