### PR TITLE
Deprecate ginga_plugins.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ sbpy.names
 API Changes
 -----------
 - Deprecated `sbpy.ginga_plugins` in favor of using `sbpy-ginga` at
-  https://github.com/NASA-Planetary-Science/sbpy-ginga
+  https://github.com/NASA-Planetary-Science/sbpy-ginga [#413]
 
 
 0.5.0 (2024-08-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ sbpy.names
   to be implemented by the MPC in anticipation of higher asteroid discovery
   rates in the LSST survey era [#406]
 
+API Changes
+-----------
+- Deprecated `sbpy.ginga_plugins` in favor of using `sbpy-ginga` at
+  https://github.com/NASA-Planetary-Science/sbpy-ginga
+
 
 0.5.0 (2024-08-28)
 ==================

--- a/sbpy/ginga_plugins/CometaryEnhancements.py
+++ b/sbpy/ginga_plugins/CometaryEnhancements.py
@@ -8,6 +8,7 @@ Ginga and available in the Operations menu.
 
 from warnings import warn
 from sbpy.exceptions import OptionalPackageUnavailable
+from astropy.utils.decorators import deprecated
 
 try:
     from ginga.GingaPlugin import LocalPlugin
@@ -30,6 +31,7 @@ except ImportError:
 from sbpy.imageanalysis import CometaryEnhancement
 
 
+@deprecated("0.6", alternative="sbpy_ginga.cometary_enhancements.CometaryEnhancements")
 class CometaryEnhancements(LocalPlugin):
     """Ginga plugin for on-the-fly cometary image enhancements."""
 
@@ -129,6 +131,14 @@ class CometaryEnhancements(LocalPlugin):
         tabw.add_widget(rho_vbox, title='1/rho')
 
         vbox.add_widget(tabw)
+
+        # Add a deprecation warning
+        hbox = Widgets.HBox()
+        text_area = Widgets.TextArea()
+        text_area.append_text("This tool is from the deprecated sbpy.ginga_plugins module.  "
+                              "Use the sbpy-ginga module instead.")
+        hbox.add_widget(text_area)
+        vbox.add_widget(hbox)
 
         # scroll bars will allow lots of content to be accessed
         top.add_widget(sw, stretch=1)

--- a/sbpy/ginga_plugins/__init__.py
+++ b/sbpy/ginga_plugins/__init__.py
@@ -2,7 +2,7 @@
 import os
 from warnings import warn
 
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 try:
     from ginga.misc.Bunch import Bunch
@@ -12,6 +12,12 @@ except ImportError:
     ))
 
     Bunch = None
+
+warn(
+    "sbpy.ginga_plugins is deprecated.  Use the `sbpy_ginga` module instead.",
+    AstropyDeprecationWarning,
+    stacklevel=2,
+)
 
 # path to these plugins
 p_path = os.path.split(__file__)[0]


### PR DESCRIPTION
Deprecate the `CometaryEnhancements` class and the `ginga_plugins` submodule itself.  Also, add a deprecation message to the `CometaryEnhancements` gui, in case users are not watching the console.  There is no documentation to edit, as this is a sort of pre-release feature that was never formally documented.

Instead use the sbpy-ginga module: https://github.com/NASA-Planetary-Science/sbpy-ginga