### PR TITLE
identify invalid comet designation with fragment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ sbpy.names
 ^^^^^^^^^^
 - Fixed `sbpy.Names.to_packed()' to raise an error in cases of invalid
   cometary designations with fragment specifiers (e.g., "2024 A-A" and
-  "2024 A-AA" now correctly raise TargetNameParseError exceptions)
+  "2024 A-AA" now correctly raise TargetNameParseError exceptions) [#417]
 
 
 0.5.0 (2024-08-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ sbpy.activity.gas
 - Replaced calls to the deprecated function `scipy.integrate.romberg` with
   `scipy.integrate.quad`.  [#412]
 
+sbpy.names
+^^^^^^^^^^
+- Fixed `sbpy.Names.to_packed()' to raise an error in cases of invalid
+  cometary designations with fragment specifiers (e.g., "2024 A-A" and
+  "2024 A-AA" now correctly raise TargetNameParseError exceptions)
+
 
 0.5.0 (2024-08-28)
 ==================

--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -130,7 +130,12 @@ class Names():
             ):
                 if s[-2] == '-':
                     frag = s[-1]
-                    num = s[6:-2]
+                    if len(s[:-2]) > 6:
+                        num = s[6:-2]
+                    else:
+                        raise TargetNameParseError(
+                            ('{} cannot be turned into a '
+                             'packed designation').format(s))
                 else:
                     frag = '0'
                     num = s[6:]

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -238,6 +238,12 @@ def test_parse_comet():
     with pytest.raises(TargetNameParseError):
         Names.parse_comet('2001 a2')
 
+    with pytest.raises(TargetNameParseError):
+        Names.parse_comet('2024 A-A')
+
+    with pytest.raises(TargetNameParseError):
+        Names.parse_comet('2024 A')
+
 
 def test_parse_asteroid():
     """Test asteroid name parsing."""


### PR DESCRIPTION
Added code to check to see if comet designation without a fragment is a valid designation or not (e.g., not passing 2024 A-A when 2024 A is not a valid designation).  Basically just checks to see if the remaining designation without the fragment suffix has enough characters to be turned into a normal packed designation.