### PR TITLE
fix incorrect asteroid-comet classification bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,11 +35,17 @@ sbpy.names
   cometary designations with fragment specifiers (e.g., "2024 A-A" and
   "2024 A-AA" now correctly raise TargetNameParseError exceptions) [#417]
 
-- Fixed `sbpy.Names.parse_comet(()' to raise an error in cases of a
+- Fixed `sbpy.Names.parse_comet()' to raise an error in cases of a
   provisional asteroid designation submitted with no space after the
   year (e.g., "2015XN77"), which was previously being interpreted as a
   well-formed comet designation (i.e., with number=2015, type=X, and
   name=N77), but now raises a TargetNameParseError [#422]
+
+- Fixed `sbpy.Names.parse_asteroid()' to raise an error in cases of a
+  provisional comet designation submitted with no forward slash between
+  the lead character and the year, and no space after the year (e.g.,
+  "P2015XN77"), which was previously being interpreted as a packed
+  asteroid designation, but now raises a TargetNameParseError [#422]
 
 0.5.0 (2024-08-28)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ sbpy.names
   cometary designations with fragment specifiers (e.g., "2024 A-A" and
   "2024 A-AA" now correctly raise TargetNameParseError exceptions) [#417]
 
+- Fixed `sbpy.Names.parse_comet(()' to raise an error in cases of a
+  provisional asteroid designation submitted with no space after the
+  year (e.g., "2015XN77"), which was previously being interpreted as a
+  well-formed comet designation (i.e., with number=2015, type=X, and
+  name=N77), but now raises a TargetNameParseError [#422]
 
 0.5.0 (2024-08-28)
 ==================

--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -588,7 +588,7 @@ class Names():
                     ident = el[4]
                     r['desig'] = Names.from_packed(ident)
                 # packed number
-                elif len(el[5]) > 0:
+                elif len(el[5]) > 0 and len(el[5]) == len(raw):
                     ident = el[5]
                     r['number'] = Names.from_packed(ident)
                 # number

--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -436,6 +436,9 @@ class Names():
                 if len(el[5]) > 0:
                     if len(el[5]) > 1:
                         r['name'] = el[5]
+                        if r['name'][1].isdigit():
+                            raise TargetNameParseError('{} does not appear to be a '
+                                                       ' comet identifier'.format(s))
 
         if len(r) == 0 or 'type' not in r:
             raise TargetNameParseError(('{} does not appear to be a '

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -244,6 +244,9 @@ def test_parse_comet():
     with pytest.raises(TargetNameParseError):
         Names.parse_comet('2024 A')
 
+    with pytest.raises(TargetNameParseError):
+        Names.parse_comet('2015XN77')
+
 
 def test_parse_asteroid():
     """Test asteroid name parsing."""

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -274,6 +274,9 @@ def test_parse_asteroid():
     with pytest.raises(TargetNameParseError):
         Names.parse_asteroid('J1')
 
+    with pytest.raises(TargetNameParseError):
+        Names.parse_asteroid('P2015XN77')
+
 
 def test_break_packed():
     with pytest.raises(TargetNameParseError):


### PR DESCRIPTION
Fixing a bug where parse_comet() incorrectly interprets input like "2015XN77" as a well-formed comet designation (where number=2015, type=X, and name=N77)