### PR TITLE
Bugfix RA column unit in sbpy-ephem CLI script.

### DIFF
--- a/docs/sbpy/data/ephem.rst
+++ b/docs/sbpy/data/ephem.rst
@@ -329,7 +329,7 @@ Center:
     # returned target: 2P
     # location: 500
               date               RA         Dec       rh  delta phase solarelong  V   Proper motion Direction
-                                deg         deg       AU    AU   deg     deg     mag    arcsec / h     deg   
+                             hourangle      deg       AU    AU   deg     deg     mag    arcsec / h     deg   
     ----------------------- ----------- ----------- ----- ----- ----- ---------- ---- ------------- ---------
     2024-08-17 00:00:00.000 21:55:57.10 -15:12:47.0 3.368 2.356   0.9      177.1 21.1         47.72     253.7
     2024-08-18 00:00:00.000 21:54:41.20 -15:18:06.0 3.373 2.361   0.7      177.5 21.1         47.54     253.9

--- a/sbpy/data/ephem/cli.py
+++ b/sbpy/data/ephem/cli.py
@@ -297,14 +297,14 @@ class EphemerisCLI:
         return eph
 
     def _format_eph(self, eph: Ephem) -> Ephem:
-        # convert RA and Dec to Angle in units of degree
-        eph["ra"] = Angle(eph["ra"], eph["ra"].unit).to("deg")
+        # convert RA and Dec to Angle
+        eph["ra"] = Angle(eph["ra"], eph["ra"].unit).to(
+            "hourangle" if self.args.radec == "hmsdms" else "deg"
+        )
         eph["dec"] = Angle(eph["dec"], eph["dec"].unit).to("deg")
 
         if self.args.radec == "hmsdms":
-            eph["ra"].info.format = lambda x: x.to_string(
-                sep=":", precision=2, unit="hourangle"
-            )
+            eph["ra"].info.format = lambda x: x.to_string(sep=":", precision=2)
             eph["dec"].info.format = lambda x: x.to_string(sep=":", precision=1)
         else:
             eph["ra"].info.format = lambda x: x.to_string(


### PR DESCRIPTION
RA columns were displayed as units of "deg" despite being units of "hourangle" (as requested).

Was:
```
(scipy) msk@notwo:~$ sbpy-ephem mpc "C/2022 R6" --start=2022-08-07 --end=2022-08-08 --step=1h
# requested target: C/2022 R6
# returned target: C/2022 R6
# location: 500
          date              RA         Dec       rh  delta phase solarelong  V   Proper motion Direction
                           deg         deg       AU    AU   deg     deg     mag    arcsec / h     deg   
----------------------- ---------- ----------- ----- ----- ----- ---------- ---- ------------- ---------
2022-08-07 00:00:00.000 3:34:49.10 -36:10:30.0 9.741 9.614   6.0       94.2 19.8         14.49     141.8
2022-08-07 01:00:00.000 3:34:49.80 -36:10:41.0 9.741 9.614   6.0       94.2 19.8         14.49     141.8
2022-08-07 02:00:00.000 3:34:50.60 -36:10:52.0 9.741 9.613   6.0       94.3 19.8         14.49     141.8
2022-08-07 03:00:00.000 3:34:51.30 -36:11:04.0 9.741 9.612   6.0       94.3 19.8         14.49     141.9
2022-08-07 04:00:00.000 3:34:52.10 -36:11:15.0  9.74 9.612   6.0       94.3 19.8         14.49     141.9
2022-08-07 05:00:00.000 3:34:52.80 -36:11:27.0  9.74 9.611   6.0       94.3 19.8         14.48     142.0
2022-08-07 06:00:00.000 3:34:53.50 -36:11:38.0  9.74 9.611   6.0       94.3 19.8         14.48     142.0
2022-08-07 07:00:00.000 3:34:54.30 -36:11:49.0  9.74  9.61   6.0       94.4 19.8         14.48     142.0
```

Now:
```
(scipy) msk@notwo:~$ sbpy-ephem mpc "C/2022 R6" --start=2022-08-07 --end=2022-08-08 --step=1h
# requested target: C/2022 R6
# returned target: C/2022 R6
# location: 500
          date              RA         Dec       rh  delta phase solarelong  V   Proper motion Direction
                        hourangle      deg       AU    AU   deg     deg     mag    arcsec / h     deg   
----------------------- ---------- ----------- ----- ----- ----- ---------- ---- ------------- ---------
2022-08-07 00:00:00.000 3:34:49.10 -36:10:30.0 9.741 9.614   6.0       94.2 19.8         14.49     141.8
2022-08-07 01:00:00.000 3:34:49.80 -36:10:41.0 9.741 9.614   6.0       94.2 19.8         14.49     141.8
2022-08-07 02:00:00.000 3:34:50.60 -36:10:52.0 9.741 9.613   6.0       94.3 19.8         14.49     141.8
2022-08-07 03:00:00.000 3:34:51.30 -36:11:04.0 9.741 9.612   6.0       94.3 19.8         14.49     141.9
2022-08-07 04:00:00.000 3:34:52.10 -36:11:15.0  9.74 9.612   6.0       94.3 19.8         14.49     141.9
2022-08-07 05:00:00.000 3:34:52.80 -36:11:27.0  9.74 9.611   6.0       94.3 19.8         14.48     142.0
2022-08-07 06:00:00.000 3:34:53.50 -36:11:38.0  9.74 9.611   6.0       94.3 19.8         14.48     142.0
2022-08-07 07:00:00.000 3:34:54.30 -36:11:49.0  9.74  9.61   6.0       94.4 19.8         14.48     142.0
...
```

