### PR TITLE
Support astropy 7.2

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -56,6 +56,7 @@ jobs:
 
         - name: Python 3.9 with oldest supported versions, measuring coverage
           linux: py39-test-oldestdeps-cov
+          coverage: codecov
   macos-test:
     name: Python 3.11 with all optional dependencies (MacOS)
     needs: [oorb-data]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -54,8 +54,8 @@ jobs:
           linux: py311-test-numpy126-alldeps-cov
           coverage: codecov
 
-        - name: Python 3.9 with oldest supported versions
-          linux: py39-test-oldestdeps
+        - name: Python 3.9 with oldest supported versions, measuring coverage
+          linux: py39-test-oldestdeps-cov
   macos-test:
     name: Python 3.11 with all optional dependencies (MacOS)
     needs: [oorb-data]

--- a/sbpy/activity/gas/productionrate.py
+++ b/sbpy/activity/gas/productionrate.py
@@ -46,6 +46,12 @@ __doctest_requires__ = {
     "from_Haser": ["astroquery"],
 }
 
+# skip until astroquery's jplspec works again
+__doctest_skip__ = {
+    "LTE.from_Drahus",
+    "from_Haser",
+}
+
 
 def intensity_conversion(mol_data):
     """

--- a/sbpy/activity/gas/productionrate.py
+++ b/sbpy/activity/gas/productionrate.py
@@ -41,9 +41,9 @@ __all__ = [
 ]
 
 __doctest_requires__ = {
-    "LTE.from_Drahus": ["astroquery>=0.4.7"],
-    "NonLTE.from_pyradex": ["astroquery>=0.4.7", "pyradex"],
-    "from_Haser": ["astroquery>=0.4.7"],
+    "LTE.from_Drahus": ["astroquery"],
+    "NonLTE.from_pyradex": ["astroquery", "pyradex"],
+    "from_Haser": ["astroquery"],
 }
 
 

--- a/sbpy/activity/gas/tests/test_prodrate_remote.py
+++ b/sbpy/activity/gas/tests/test_prodrate_remote.py
@@ -69,7 +69,7 @@ def data_path(filename):
 
 @pytest.mark.remote_data
 def test_remote_prodrate_simple_hcn():
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     hcn = Table.read(data_path("HCN.csv"), format="ascii.csv")
 
@@ -114,7 +114,7 @@ def test_remote_prodrate_simple_hcn():
 
 @pytest.mark.remote_data
 def test_remote_prodrate_simple_ch3oh():
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     ch3oh = Table.read(data_path("CH3OH.csv"), format="ascii.csv")
     temp_estimate = 47.0 * u.K
@@ -159,7 +159,7 @@ def test_remote_prodrate_simple_ch3oh():
 @pytest.mark.skip
 @pytest.mark.remote_data
 def test_einstein():
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     transition_freq_list = [
         (1611.7935180 * u.GHz).to("MHz"),
@@ -213,7 +213,7 @@ def test_einstein():
 
 @pytest.mark.remote_data
 def test_Haser_prodrate():
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     co = Table.read(data_path("CO.csv"), format="ascii.csv")
 
@@ -276,7 +276,7 @@ See https://github.com/keflavich/pyradex for installment
 @pytest.mark.remote_data
 def test_Haser_pyradex():
     pytest.importorskip("pyradex")
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     co = Table.read(data_path("CO.csv"), format="ascii.csv")
 
@@ -331,7 +331,7 @@ def test_Haser_pyradex():
 @pytest.mark.remote_data
 def test_intensity_conversion():
     # test untested case for intensity conversion function
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     temp_estimate = 47.0 * u.K
     # vgas = 0.8 * u.km / u.s
@@ -348,7 +348,7 @@ def test_intensity_conversion():
 @pytest.mark.remote_data
 def test_einsteincoeff_case():
     # test untested case for einstein coefficient
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     temp_estimate = 47.0 * u.K
     # vgas = 0.8 * u.km / u.s
@@ -394,7 +394,7 @@ See https://github.com/keflavich/pyradex for installment
 @pytest.mark.remote_data
 def test_pyradex_case():
     pytest.importorskip("pyradex")
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     transition_freq = (177.196 * u.GHz).to(u.MHz)
     mol_tag = 29002
@@ -417,7 +417,7 @@ def test_pyradex_case():
 @pytest.mark.remote_data
 def test_Haser_prodrate_pyradex(mock_nonlte):
     pytest.importorskip("pyradex")
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     co = Table.read(data_path("CO.csv"), format="ascii.csv")
 
@@ -471,7 +471,7 @@ def test_Haser_prodrate_pyradex(mock_nonlte):
 
 @pytest.mark.remote_data
 def test_pyradex_cdensity(mock_nonlte):
-    pytest.importorskip("astroquery", minversion="0.4.7")
+    pytest.importorskip("astroquery", minversion="0.4.12")
 
     transition_freq = (177.196 * u.GHz).to(u.MHz)
     mol_tag = 29002

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -2,6 +2,7 @@
 
 import pytest
 import warnings
+from packaging.version import Version
 
 from numpy.testing import assert_allclose
 import astropy.units as u
@@ -15,26 +16,27 @@ from ..core import QueryError
 from ..ephem import Ephem
 from ..orbit import Orbit
 
-pytest.importorskip("astroquery")
+astroquery = pytest.importorskip("astroquery")
+
 
 # retreived from Horizons on 23 Apr 2020
 CERES = {
-    'targetname': '1 Ceres',
-    'H': u.Quantity(3.4, 'mag'),
-    'G': 0.12,
-    'e': 0.07741102040801928,
-    'q': u.Quantity(2.55375156, 'au'),
-    'incl': u.Quantity(10.58910839, 'deg'),
-    'Omega': u.Quantity(80.29081558, 'deg'),
-    'w': u.Quantity(73.7435117, 'deg'),
-    'n': u.Quantity(0.21401711, 'deg / d'),
-    'M': u.Quantity(154.70418799, 'deg'),
-    'nu': u.Quantity(158.18663933, 'deg'),
-    'a': u.Quantity(2.76802739, 'AU'),
-    'Q': u.Quantity(2.98230321, 'AU'),
-    'P': u.Quantity(1682.10848349, 'd'),
-    'epoch': Time(2458963.26397076, scale='tdb', format='jd'),
-    'Tp': Time(2458240.40500675, scale='tdb', format='jd')
+    "targetname": "1 Ceres",
+    "H": u.Quantity(3.4, "mag"),
+    "G": 0.12,
+    "e": 0.07741102040801928,
+    "q": u.Quantity(2.55375156, "au"),
+    "incl": u.Quantity(10.58910839, "deg"),
+    "Omega": u.Quantity(80.29081558, "deg"),
+    "w": u.Quantity(73.7435117, "deg"),
+    "n": u.Quantity(0.21401711, "deg / d"),
+    "M": u.Quantity(154.70418799, "deg"),
+    "nu": u.Quantity(158.18663933, "deg"),
+    "a": u.Quantity(2.76802739, "AU"),
+    "Q": u.Quantity(2.98230321, "AU"),
+    "P": u.Quantity(1682.10848349, "d"),
+    "epoch": Time(2458963.26397076, scale="tdb", format="jd"),
+    "Tp": Time(2458240.40500675, scale="tdb", format="jd"),
 }
 
 
@@ -43,8 +45,8 @@ class TestEphemFromHorizons:
 
     def test_current_epoch(self):
         now = Time.now()
-        data = Ephem.from_horizons('Ceres')
-        assert_allclose(data['epoch'].jd, now.jd)
+        data = Ephem.from_horizons("Ceres")
+        assert_allclose(data["epoch"].jd, now.jd)
 
     def test_daterange_step(self):
         """Test start/stop/step.
@@ -53,73 +55,78 @@ class TestEphemFromHorizons:
         sbpy PR#247.
 
         """
-        epochs = {'start': Time('2018-01-02', format='iso'),
-                  'stop': Time('2018-01-05', format='iso'),
-                  'step': 6*u.hour}
+        epochs = {
+            "start": Time("2018-01-02", format="iso"),
+            "stop": Time("2018-01-05", format="iso"),
+            "step": 6 * u.hour,
+        }
         epochs_saved = epochs.copy()
 
-        data = Ephem.from_horizons('Ceres', epochs=epochs)
+        data = Ephem.from_horizons("Ceres", epochs=epochs)
 
         assert len(data.table) == 13
-        assert (epochs == epochs_saved) and isinstance(epochs['start'], Time)
+        assert (epochs == epochs_saved) and isinstance(epochs["start"], Time)
 
     def test_daterange_number(self):
-        epochs = {'start': Time('2018-01-02', format='iso'),
-                  'stop': Time('2018-01-05', format='iso'),
-                  'number': 10}
-        data = Ephem.from_horizons('Ceres', epochs=epochs)
+        epochs = {
+            "start": Time("2018-01-02", format="iso"),
+            "stop": Time("2018-01-05", format="iso"),
+            "number": 10,
+        }
+        data = Ephem.from_horizons("Ceres", epochs=epochs)
         assert len(data.table) == 10
 
     def test_Time_list(self):
-        epochs = Time(['2018-01-01', '2018-01-02'])
-        data = Ephem.from_horizons('Ceres', epochs=epochs)
+        epochs = Time(["2018-01-01", "2018-01-02"])
+        data = Ephem.from_horizons("Ceres", epochs=epochs)
         assert len(data.table) == 2
 
     def test_epochs_order(self):
         """sbpy GitHub issue #317: Horizons returns sorted dates."""
-        epochs = Time(['2010-01-02', '2010-01-01'])
+        epochs = Time(["2010-01-02", "2010-01-01"])
         assert epochs[0] > epochs[1]
-        data = Ephem.from_horizons('Ceres', epochs=epochs)
+        data = Ephem.from_horizons("Ceres", epochs=epochs)
         # verify that from_horizons returns the dates in the order they were
         # requested
-        assert_allclose(epochs.mjd, data['date'].mjd)
+        assert_allclose(epochs.mjd, data["date"].mjd)
 
     def test_multiple_objects(self):
-        data = Ephem.from_horizons(['Ceres', 'Pallas'])
+        data = Ephem.from_horizons(["Ceres", "Pallas"])
         assert len(data.table) == 2
 
     def test_Earthlocation(self):
-        lowell = EarthLocation.of_site('Lowell Observatory')
-        data = Ephem.from_horizons(1, epochs=Time('2018-01-01',
-                                                  format='iso'),
-                                   location=lowell)
+        lowell = EarthLocation.of_site("Lowell Observatory")
+        data = Ephem.from_horizons(
+            1, epochs=Time("2018-01-01", format="iso"), location=lowell
+        )
         assert len(data.table) == 1
 
     def test_bib(self):
         with bib.Tracking():
-            Ephem.from_horizons(['Ceres', 'Pallas'])
-            assert 'sbpy.data.ephem.core.Ephem.from_horizons' in bib.show()
+            Ephem.from_horizons(["Ceres", "Pallas"])
+            assert "sbpy.data.ephem.core.Ephem.from_horizons" in bib.show()
         bib.reset()
 
     def test_timescale(self):
         # test same timescale
-        time = Time('2020-01-01 00:00', format='iso', scale='utc')
+        time = Time("2020-01-01 00:00", format="iso", scale="utc")
         a = Ephem.from_horizons(1, epochs=time)
-        assert a['epoch'].scale == 'utc'
-        assert a['epoch'].utc.jd == 2458849.5
+        assert a["epoch"].scale == "utc"
+        assert a["epoch"].utc.jd == 2458849.5
 
         # test different timescale (and check for warning)
-        time = Time('2020-01-01 00:00', format='iso', scale='tdb')
+        time = Time("2020-01-01 00:00", format="iso", scale="tdb")
         with warnings.catch_warnings(record=True) as w:
             a = Ephem.from_horizons(1, epochs=time)
-            assert any(["astroquery.jplhorizons" in str(w[i].message)
-                        for i in range(len(w))])
-        assert a['epoch'].scale == 'utc'
-        assert_allclose(a['epoch'][0].utc.jd, 2458849.49919926)
+            assert any(
+                ["astroquery.jplhorizons" in str(w[i].message) for i in range(len(w))]
+            )
+        assert a["epoch"].scale == "utc"
+        assert_allclose(a["epoch"][0].utc.jd, 2458849.49919926)
 
     def test_queryfail(self):
         with pytest.raises(QueryError):
-            Ephem.from_horizons('target does not exist')
+            Ephem.from_horizons("target does not exist")
 
     def test_output_epochs(self):
         from astropy.utils.iers import IERSRangeError
@@ -129,23 +136,23 @@ class TestEphemFromHorizons:
         # because it has to download some data, which might fail;
         # if that happens, skip the test
         try:
-            epochs = Time(2437655.5, format='jd', scale='utc')
+            epochs = Time(2437655.5, format="jd", scale="utc")
             a = Ephem.from_horizons(1, epochs=epochs)
-            assert a['epoch'][0].scale == 'utc'
+            assert a["epoch"][0].scale == "utc"
         except IERSRangeError:
             pass
 
         # all utc
-        epochs = Time(2437675.5, format='jd', scale='utc')
+        epochs = Time(2437675.5, format="jd", scale="utc")
         a = Ephem.from_horizons(1, epochs=epochs)
-        assert a['epoch'][0].scale == 'utc'
+        assert a["epoch"][0].scale == "utc"
 
         # mixed ut1 and utc
         # same as above
         try:
-            epochs = Time([2437655.5, 2437675.5], format='jd', scale='utc')
+            epochs = Time([2437655.5, 2437675.5], format="jd", scale="utc")
             a = Ephem.from_horizons(1, epochs=epochs)
-            assert a['epoch'].scale == 'utc'
+            assert a["epoch"].scale == "utc"
         except IERSRangeError:
             pass
 
@@ -155,55 +162,51 @@ class TestEphemFromHorizons:
         Regression test for #242.
 
         """
-        e = Ephem.from_horizons(1, quantities='1')  # just RA, Dec
+        e = Ephem.from_horizons(1, quantities="1")  # just RA, Dec
         assert len(e) == 1
-        e = Ephem.from_horizons(1, quantities='19')  # just rh and delta-rh
+        e = Ephem.from_horizons(1, quantities="19")  # just rh and delta-rh
         assert len(e) == 1
 
     def test_invalid_epochs(self):
         with pytest.raises(ValueError):
-            Ephem.from_horizons('Ceres', epochs='2020-04-01')
+            Ephem.from_horizons("Ceres", epochs="2020-04-01")
 
 
 @pytest.mark.remote_data
 class TestEphemFromMPC:
     def test_single_epoch_now(self):
-        eph = Ephem.from_mpc('Ceres')
+        eph = Ephem.from_mpc("Ceres")
         assert len(eph.table) == 1
 
     def test_single_epoch(self):
         # utc
-        eph1 = Ephem.from_mpc('Ceres',
-                              epochs=Time('2018-10-01', scale='utc'))
+        eph1 = Ephem.from_mpc("Ceres", epochs=Time("2018-10-01", scale="utc"))
         assert len(eph1.table) == 1
 
         # tdb
         with warnings.catch_warnings(record=True) as w:
-            eph2 = Ephem.from_mpc('Ceres',
-                                  epochs=Time('2018-10-01', scale='tdb'))
-            assert any(["astroquery.mpc" in str(w[i].message)
-                        for i in range(len(w))])
-        assert all(eph2['epoch'] != eph1['epoch'])
+            eph2 = Ephem.from_mpc("Ceres", epochs=Time("2018-10-01", scale="tdb"))
+            assert any(["astroquery.mpc" in str(w[i].message) for i in range(len(w))])
+        assert all(eph2["epoch"] != eph1["epoch"])
 
     def test_multiple_epochs(self):
         # utc
-        eph1 = Ephem.from_mpc('Ceres', epochs=Time(['2018-10-01',
-                                                    '2019-10-01'],
-                                                   scale='utc'))
+        eph1 = Ephem.from_mpc(
+            "Ceres", epochs=Time(["2018-10-01", "2019-10-01"], scale="utc")
+        )
         assert len(eph1.table) == 2
 
         # tai
         with warnings.catch_warnings(record=True) as w:
-            eph2 = Ephem.from_mpc('Ceres', epochs=Time(['2018-10-01',
-                                                        '2019-10-01'],
-                                                       scale='tai'))
-            assert any(["astroquery.mpc" in str(w[i].message)
-                        for i in range(len(w))])
-        assert all(eph2['epoch'] != eph1['epoch'])
+            eph2 = Ephem.from_mpc(
+                "Ceres", epochs=Time(["2018-10-01", "2019-10-01"], scale="tai")
+            )
+            assert any(["astroquery.mpc" in str(w[i].message) for i in range(len(w))])
+        assert all(eph2["epoch"] != eph1["epoch"])
 
     def test_invalid_epochs(self):
         with pytest.raises(ValueError):
-            Ephem.from_mpc('Ceres', epochs='2020-04-01')
+            Ephem.from_mpc("Ceres", epochs="2020-04-01")
 
     def test_start_stop_step(self):
         """Test start/stop/step.
@@ -214,93 +217,91 @@ class TestEphemFromMPC:
         """
 
         # utc
-        epochs = dict(start=Time('2018-10-01'), stop=Time('2018-10-31'),
-                      step=1*u.d)
+        epochs = dict(start=Time("2018-10-01"), stop=Time("2018-10-31"), step=1 * u.d)
         epochs_saved = epochs.copy()
-        eph1 = Ephem.from_mpc('Ceres', epochs=epochs)
+        eph1 = Ephem.from_mpc("Ceres", epochs=epochs)
         assert len(eph1.table) == 31
-        assert (epochs == epochs_saved) and isinstance(epochs['start'], Time)
+        assert (epochs == epochs_saved) and isinstance(epochs["start"], Time)
 
         # tt
-        epochs = dict(start=Time('2018-10-01', scale='tt'),
-                      stop=Time('2018-10-31', scale='tt'),
-                      step=1*u.d)
+        epochs = dict(
+            start=Time("2018-10-01", scale="tt"),
+            stop=Time("2018-10-31", scale="tt"),
+            step=1 * u.d,
+        )
         with warnings.catch_warnings(record=True) as w:
-            eph2 = Ephem.from_mpc('Ceres', epochs=epochs)
-            assert any(["astroquery.mpc" in str(w[i].message)
-                        for i in range(len(w))])
-        assert all(eph2['epoch'] != eph1['epoch'])
+            eph2 = Ephem.from_mpc("Ceres", epochs=epochs)
+            assert any(["astroquery.mpc" in str(w[i].message) for i in range(len(w))])
+        assert all(eph2["epoch"] != eph1["epoch"])
 
     def test_minute_steps_pr88(self):
         """https://github.com/NASA-Planetary-Science/sbpy/pull/88"""
-        epochs = dict(start=Time('2018-10-01'), step=1*u.min, number=10)
-        eph = Ephem.from_mpc('Ceres', epochs=epochs)
+        epochs = dict(start=Time("2018-10-01"), step=1 * u.min, number=10)
+        eph = Ephem.from_mpc("Ceres", epochs=epochs)
         assert len(eph.table) == 10
 
     def test_start_stop_no_step(self):
         with pytest.raises(QueryError):
-            eph = Ephem.from_mpc('Ceres', epochs={
-                'start': Time('2018-10-01'),
-                'stop': Time('2018-10-31')})
+            Ephem.from_mpc(
+                "Ceres",
+                epochs={"start": Time("2018-10-01"), "stop": Time("2018-10-31")},
+            )
 
     def test_start_step_number(self):
-        epochs = dict(start=Time('2018-10-01'), step=1*u.d, number=31)
-        eph = Ephem.from_mpc('Ceres', epochs=epochs)
+        epochs = dict(start=Time("2018-10-01"), step=1 * u.d, number=31)
+        eph = Ephem.from_mpc("Ceres", epochs=epochs)
         assert len(eph.table) == 31
-        assert eph['Date'][-1] == '2018-10-31 00:00:00.000'
+        assert eph["Date"][-1] == "2018-10-31 00:00:00.000"
 
     def test_start_stop_number(self):
-        epochs = dict(start=Time('2018-10-01'), stop=Time('2018-10-02'),
-                      number=31)
-        eph = Ephem.from_mpc('Ceres', epochs=epochs)
+        epochs = dict(start=Time("2018-10-01"), stop=Time("2018-10-02"), number=31)
+        eph = Ephem.from_mpc("Ceres", epochs=epochs)
         assert len(eph.table) == 31
 
     def test_start_stop_jd(self):
-        epochs = {'start': Time(2458396.5, format='jd'),
-                  'stop': Time(2458397.5, format='jd'),
-                  'step': 1*u.d}
-        eph = Ephem.from_mpc('Ceres', epochs=epochs)
-        assert eph['Date'][0] == '2018-10-05 00:00:00.000'
-        assert eph['Date'][1] == '2018-10-06 00:00:00.000'
+        epochs = {
+            "start": Time(2458396.5, format="jd"),
+            "stop": Time(2458397.5, format="jd"),
+            "step": 1 * u.d,
+        }
+        eph = Ephem.from_mpc("Ceres", epochs=epochs)
+        assert eph["Date"][0] == "2018-10-05 00:00:00.000"
+        assert eph["Date"][1] == "2018-10-06 00:00:00.000"
 
     def test_step_unit(self):
         with pytest.raises(QueryError):
-            Ephem.from_mpc('Ceres', epochs={
-                'start': Time('2018-10-01'),
-                'step': 1*u.year})
+            Ephem.from_mpc(
+                "Ceres", epochs={"start": Time("2018-10-01"), "step": 1 * u.year}
+            )
 
     def test_ra_dec_format(self):
-        epochs = dict(start=Time('2018-10-01'),
-                      step=1*u.d, number=31)
-        ra_format = {'sep': ':', 'unit': 'hourangle', 'precision': 1}
-        dec_format = {'sep': ':', 'precision': 1}
-        eph = Ephem.from_mpc('Ceres', epochs=epochs, ra_format=ra_format,
-                             dec_format=dec_format)
+        epochs = dict(start=Time("2018-10-01"), step=1 * u.d, number=31)
+        ra_format = {"sep": ":", "unit": "hourangle", "precision": 1}
+        dec_format = {"sep": ":", "precision": 1}
+        eph = Ephem.from_mpc(
+            "Ceres", epochs=epochs, ra_format=ra_format, dec_format=dec_format
+        )
 
         # round-trip through a string, then inspect RA, Dec
         tab = ascii.read(
-            '\n'.join(eph.table.pformat(
-                show_unit=False,
-                max_lines=-1,
-                max_width=-1
-            )),
-            format='fixed_width_two_line'
+            "\n".join(eph.table.pformat(show_unit=False, max_lines=-1, max_width=-1)),
+            format="fixed_width_two_line",
         )
-        assert isinstance(tab['RA'][0], str)
-        assert isinstance(tab['Dec'][0], str)
+        assert isinstance(tab["RA"][0], str)
+        assert isinstance(tab["Dec"][0], str)
 
     def test_multiple_targets(self):
-        eph = Ephem.from_mpc(['Ceres', 'Pallas', 'Vesta'])
-        assert all(eph['Targetname'].data == ['Ceres', 'Pallas', 'Vesta'])
+        eph = Ephem.from_mpc(["Ceres", "Pallas", "Vesta"])
+        assert all(eph["Targetname"].data == ["Ceres", "Pallas", "Vesta"])
 
     def test_queryfail(self):
         with pytest.raises(QueryError):
-            Ephem.from_mpc('target does not exist')
+            Ephem.from_mpc("target does not exist")
 
     def test_bib(self):
         with bib.Tracking():
-            Ephem.from_mpc(['Ceres', 'Pallas'])
-            assert 'sbpy.data.ephem.core.Ephem.from_mpc' in bib.show()
+            Ephem.from_mpc(["Ceres", "Pallas"])
+            assert "sbpy.data.ephem.core.Ephem.from_mpc" in bib.show()
         bib.reset()
 
 
@@ -308,56 +309,63 @@ class TestEphemFromMPC:
 class TestEphemFromMiriade:
     def test_singleobj_now(self):
         eph = Ephem.from_miriade("Ceres")
-        assert_quantity_allclose(eph['epoch'][0].jd, Time.now().jd)
+        assert_quantity_allclose(eph["epoch"][0].jd, Time.now().jd)
 
     def test_multiobj_now(self):
-        eph = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                 epochs=Time.now())
+        eph = Ephem.from_miriade(["Ceres", "Pallas"], epochs=Time.now())
         assert len(eph.table) == 2
 
     def test_epochTime(self):
         # utc
-        eph1 = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                  epochs=Time('2018-10-01', scale='utc'))
-        assert_quantity_allclose(eph1['epoch'][0].jd, Time('2018-10-01').jd)
+        eph1 = Ephem.from_miriade(
+            ["Ceres", "Pallas"], epochs=Time("2018-10-01", scale="utc")
+        )
+        assert_quantity_allclose(eph1["epoch"][0].jd, Time("2018-10-01").jd)
 
         # tt
         with warnings.catch_warnings(record=True) as w:
-            eph2 = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                      epochs=Time('2018-10-01', scale='tt'))
-            assert any(["astroquery.imcce" in str(w[i].message)
-                        for i in range(len(w))])
-        assert all(eph1['epoch'] != eph2['epoch'])
+            eph2 = Ephem.from_miriade(
+                ["Ceres", "Pallas"], epochs=Time("2018-10-01", scale="tt")
+            )
+            assert any(["astroquery.imcce" in str(w[i].message) for i in range(len(w))])
+        assert all(eph1["epoch"] != eph2["epoch"])
 
     def test_epochTimemult(self):
-        eph = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                 epochs=Time(['2018-10-01', '2018-10-02']))
-        assert_quantity_allclose(eph['epoch'][0].jd, Time('2018-10-01').jd)
+        eph = Ephem.from_miriade(
+            ["Ceres", "Pallas"], epochs=Time(["2018-10-01", "2018-10-02"])
+        )
+        assert_quantity_allclose(eph["epoch"][0].jd, Time("2018-10-01").jd)
 
     def test_epochstart(self):
-        eph = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                 epochs={'start': Time('2018-10-01')})
-        assert_quantity_allclose(eph['epoch'][0].jd, Time('2018-10-01').jd)
+        eph = Ephem.from_miriade(
+            ["Ceres", "Pallas"], epochs={"start": Time("2018-10-01")}
+        )
+        assert_quantity_allclose(eph["epoch"][0].jd, Time("2018-10-01").jd)
 
     def test_epochrange_number(self):
         # utc
-        eph1 = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                  epochs={'start': Time('2018-10-01'),
-                                          'stop': Time('2018-11-01'),
-                                          'number': 10})
+        eph1 = Ephem.from_miriade(
+            ["Ceres", "Pallas"],
+            epochs={
+                "start": Time("2018-10-01"),
+                "stop": Time("2018-11-01"),
+                "number": 10,
+            },
+        )
         assert len(eph1.table) == 20
 
         # tdb
         with warnings.catch_warnings(record=True) as w:
-            eph2 = Ephem.from_miriade(["Ceres", 'Pallas'],
-                                      epochs={'start': Time('2018-10-01',
-                                                            scale='tdb'),
-                                              'stop': Time('2018-11-01',
-                                                           scale='tdb'),
-                                              'number': 10})
-            assert any(["astroquery.imcce" in str(w[i].message)
-                        for i in range(len(w))])
-        assert all(eph1['epoch'] != eph2['epoch'])
+            eph2 = Ephem.from_miriade(
+                ["Ceres", "Pallas"],
+                epochs={
+                    "start": Time("2018-10-01", scale="tdb"),
+                    "stop": Time("2018-11-01", scale="tdb"),
+                    "number": 10,
+                },
+            )
+            assert any(["astroquery.imcce" in str(w[i].message) for i in range(len(w))])
+        assert all(eph1["epoch"] != eph2["epoch"])
 
     def test_epochrange_step(self):
         """Test start/stop/step.
@@ -367,40 +375,39 @@ class TestEphemFromMiriade:
 
         """
         epochs = {
-            'start': Time('2018-10-01'),
-            'stop': Time('2018-10-10'),
-            'step': 0.5*u.d
+            "start": Time("2018-10-01"),
+            "stop": Time("2018-10-10"),
+            "step": 0.5 * u.d,
         }
         epochs_saved = epochs.copy()
-        eph = Ephem.from_miriade(["Ceres", 'Pallas'], epochs=epochs)
+        eph = Ephem.from_miriade(["Ceres", "Pallas"], epochs=epochs)
         assert len(eph.table) == 38
-        assert (epochs == epochs_saved) and isinstance(epochs['start'], Time)
+        assert (epochs == epochs_saved) and isinstance(epochs["start"], Time)
 
     def test_invalid_epochs(self):
         with pytest.raises(ValueError):
-            Ephem.from_miriade('Ceres', epochs='2020-04-01')
+            Ephem.from_miriade("Ceres", epochs="2020-04-01")
 
     def test_iaulocation(self):
-        eph1 = Ephem.from_miriade(
-            "Ceres", location='G37', epochs=Time('2019-01-01'))
-        eph2 = Ephem.from_miriade("Ceres", epochs=Time('2019-01-01'))
-        assert abs(eph1['RA'][0]-eph2['RA'][0]) > 0.00001*u.deg
+        eph1 = Ephem.from_miriade("Ceres", location="G37", epochs=Time("2019-01-01"))
+        eph2 = Ephem.from_miriade("Ceres", epochs=Time("2019-01-01"))
+        assert abs(eph1["RA"][0] - eph2["RA"][0]) > 0.00001 * u.deg
 
     def test_EarthLocation(self):
-        lowell = EarthLocation.of_site('Lowell Observatory')
-        eph1 = Ephem.from_miriade(
-            "Ceres", location=lowell, epochs=Time('2019-01-01'))
-        eph2 = Ephem.from_miriade("Ceres", epochs=Time('2019-01-01'))
-        assert abs(eph1['RA'][0]-eph2['RA'][0]) > 0.0001*u.deg
+        lowell = EarthLocation.of_site("Lowell Observatory")
+        eph1 = Ephem.from_miriade("Ceres", location=lowell, epochs=Time("2019-01-01"))
+        eph2 = Ephem.from_miriade("Ceres", epochs=Time("2019-01-01"))
+        assert abs(eph1["RA"][0] - eph2["RA"][0]) > 0.0001 * u.deg
 
+    @pytest.mark.xfail(reason="need astroquery to support updated miriade service")
     def test_queryfail(self):
         with pytest.raises(QueryError):
-            Ephem.from_miriade('target does not exist')
+            Ephem.from_miriade("target does not exist")
 
     def test_bib(self):
         with bib.Tracking():
-            Ephem.from_miriade(['Ceres', 'Pallas'])
-            assert 'sbpy.data.ephem.core.Ephem.from_miriade' in bib.show()
+            Ephem.from_miriade(["Ceres", "Pallas"])
+            assert "sbpy.data.ephem.core.Ephem.from_miriade" in bib.show()
         bib.reset()
 
 
@@ -411,19 +418,20 @@ class TestEphemFromOorb:
 
         pytest.importorskip("pyoorb")
 
-        orbit = Orbit.from_horizons('Ceres')
-        horizons_ephem = Ephem.from_horizons('Ceres', location='500')
+        orbit = Orbit.from_horizons("Ceres")
+        horizons_ephem = Ephem.from_horizons("Ceres", location="500")
         oo_ephem = Ephem.from_oo(orbit)
 
-        u.isclose(horizons_ephem['ra'][0], oo_ephem['ra'][0])
-        u.isclose(horizons_ephem['dec'][0], oo_ephem['dec'][0])
-        u.isclose(horizons_ephem['RA*cos(Dec)_rate'][0],
-                  oo_ephem['RA*cos(Dec)_rate'][0])
-        u.isclose(horizons_ephem['dec_rate'][0], oo_ephem['dec_rate'][0])
-        u.isclose(horizons_ephem['alpha'][0], oo_ephem['alpha'][0])
-        u.isclose(horizons_ephem['r'][0], oo_ephem['r'][0])
-        u.isclose(horizons_ephem['delta'][0], oo_ephem['delta'][0])
-        u.isclose(horizons_ephem['V'][0], oo_ephem['V'][0])
-        u.isclose(horizons_ephem['hlon'][0], oo_ephem['hlon'][0])
-        u.isclose(horizons_ephem['hlat'][0], oo_ephem['hlat'][0])
-        u.isclose(horizons_ephem['EL'][0], oo_ephem['EL'][0])
+        u.isclose(horizons_ephem["ra"][0], oo_ephem["ra"][0])
+        u.isclose(horizons_ephem["dec"][0], oo_ephem["dec"][0])
+        u.isclose(
+            horizons_ephem["RA*cos(Dec)_rate"][0], oo_ephem["RA*cos(Dec)_rate"][0]
+        )
+        u.isclose(horizons_ephem["dec_rate"][0], oo_ephem["dec_rate"][0])
+        u.isclose(horizons_ephem["alpha"][0], oo_ephem["alpha"][0])
+        u.isclose(horizons_ephem["r"][0], oo_ephem["r"][0])
+        u.isclose(horizons_ephem["delta"][0], oo_ephem["delta"][0])
+        u.isclose(horizons_ephem["V"][0], oo_ephem["V"][0])
+        u.isclose(horizons_ephem["hlon"][0], oo_ephem["hlon"][0])
+        u.isclose(horizons_ephem["hlat"][0], oo_ephem["hlat"][0])
+        u.isclose(horizons_ephem["EL"][0], oo_ephem["EL"][0])

--- a/sbpy/data/tests/test_ephem_remote.py
+++ b/sbpy/data/tests/test_ephem_remote.py
@@ -2,7 +2,6 @@
 
 import pytest
 import warnings
-from packaging.version import Version
 
 from numpy.testing import assert_allclose
 import astropy.units as u

--- a/sbpy/data/tests/test_obs_remote.py
+++ b/sbpy/data/tests/test_obs_remote.py
@@ -17,38 +17,38 @@ class TestObsfromMPC:
 
     def test_simple(self):
         # asteroid
-        data = Obs.from_mpc('12893')
+        data = Obs.from_mpc("12893")
         assert len(data) >= 1605
 
         # comet
-        data = Obs.from_mpc('235P')
+        data = Obs.from_mpc("235P")
         assert len(data) >= 274
 
     def test_manual_idtypes(self):
-        data = Obs.from_mpc('12893', id_type='asteroid number')
+        data = Obs.from_mpc("12893", id_type="asteroid number")
         assert len(data) >= 1605
 
-        data = Obs.from_mpc('1998 QS55', id_type='asteroid designation')
+        data = Obs.from_mpc("1998 QS55", id_type="asteroid designation")
         assert len(data) >= 46
 
-        data = Obs.from_mpc('2019 AA', id_type='asteroid designation')
+        data = Obs.from_mpc("2019 AA", id_type="asteroid designation")
         assert len(data) >= 33
 
         # comet
-        data = Obs.from_mpc('235P', id_type='comet number')
+        data = Obs.from_mpc("235P", id_type="comet number")
         assert len(data) >= 274
 
-        data = Obs.from_mpc('P/2010 F2', id_type='comet designation')
+        data = Obs.from_mpc("P/2010 F2", id_type="comet designation")
         assert len(data) >= 35
 
     def test_break(self):
         with pytest.raises(QueryError):
-            Obs.from_mpc('2019 AA345', id_type='asteroid designation')
+            Obs.from_mpc("2019 AA345", id_type="asteroid designation")
 
     def test_bib(self):
         bib.track()
-        Obs.from_mpc('235P')
-        assert 'sbpy.data.obs.Obs.from_mpc' in bib.to_text()
+        Obs.from_mpc("235P")
+        assert "sbpy.data.obs.Obs.from_mpc" in bib.show()
 
 
 @pytest.mark.remote_data
@@ -56,52 +56,70 @@ class TestSupplement:
 
     def test_jplhorizons(self):
         bib.track()
-        obs = Obs.from_dict({'epoch': Time([2451200, 2451201], format='jd'),
-                             'mag': [12, 13]*u.mag,
-                             'targetname': ['3552', '3552']})
-        data = obs.supplement(service='jplhorizons', modify_fieldnames='obs')
+        obs = Obs.from_dict(
+            {
+                "epoch": Time([2451200, 2451201], format="jd"),
+                "mag": [12, 13] * u.mag,
+                "targetname": ["3552", "3552"],
+            }
+        )
+        data = obs.supplement(service="jplhorizons", modify_fieldnames="obs")
         assert len(data.field_names) > len(obs.field_names)
-        assert 'targetname_obs' in data.field_names
+        assert "targetname_obs" in data.field_names
 
-        data = obs.supplement(service='jplhorizons', modify_fieldnames='eph')
+        data = obs.supplement(service="jplhorizons", modify_fieldnames="eph")
         assert len(data.field_names) > len(obs.field_names)
-        assert 'targetname_eph' in data.field_names
+        assert "targetname_eph" in data.field_names
 
-        assert 'sbpy.data.ephem.core.Ephem.from_horizons' in bib.to_text()
+        assert "sbpy.data.ephem.core.Ephem.from_horizons" in bib.show()
 
     def test_mpc(self):
         bib.track()
-        obs = Obs.from_dict({'epoch': Time([2451200, 2451201], format='jd'),
-                             'mag': [12, 13]*u.mag,
-                             'targetname': ['3552', '3552']})
-        data = obs.supplement(service='mpc')
+        obs = Obs.from_dict(
+            {
+                "epoch": Time([2451200, 2451201], format="jd"),
+                "mag": [12, 13] * u.mag,
+                "targetname": ["3552", "3552"],
+            }
+        )
+        data = obs.supplement(service="mpc")
         assert len(data.field_names) > len(obs.field_names)
 
-        assert 'sbpy.data.ephem.core.Ephem.from_mpc' in bib.to_text()
+        assert "sbpy.data.ephem.core.Ephem.from_mpc" in bib.show()
 
     def test_miriade(self):
         bib.track()
-        obs = Obs.from_dict({'epoch': Time([2451200, 2451201], format='jd'),
-                             'mag': [12, 13]*u.mag,
-                             'targetname': ['3552', '3552']})
-        data = obs.supplement(service='miriade')
+        obs = Obs.from_dict(
+            {
+                "epoch": Time([2451200, 2451201], format="jd"),
+                "mag": [12, 13] * u.mag,
+                "targetname": ["3552", "3552"],
+            }
+        )
+        data = obs.supplement(service="miriade")
         assert len(data.field_names) > len(obs.field_names)
 
-        assert 'sbpy.data.ephem.core.Ephem.from_miriade' in bib.to_text()
+        assert "sbpy.data.ephem.core.Ephem.from_miriade" in bib.show()
 
     def test_breaks(self):
-        obs = Obs.from_dict({'epoch': Time([2451200, 2451201], format='jd'),
-                             'mag': [12, 13]*u.mag,
-                             'targetname': ['3552', '3552']})
+        obs = Obs.from_dict(
+            {
+                "epoch": Time([2451200, 2451201], format="jd"),
+                "mag": [12, 13] * u.mag,
+                "targetname": ["3552", "3552"],
+            }
+        )
 
         with pytest.raises(QueryError):
-            obs.supplement(service='this will not work')
+            obs.supplement(service="this will not work")
 
     def test_multiple_jplhorizons(self):
-        obs = Obs.from_dict({'epoch': Time([2451200, 2451201,
-                                            2451200, 2451201], format='jd'),
-                             'mag': [12, 13, 16, 17]*u.mag,
-                             'targetname': ['3552', '3552',
-                                            '12893', '12893']})
-        data = obs.supplement(service='jplhorizons', modify_fieldnames='obs')
-        assert len(set(data['targetname'])) == 2
+        obs = Obs.from_dict(
+            {
+                "epoch": Time([2451200, 2451201, 2451200, 2451201], format="jd"),
+                "mag": [12, 13, 16, 17] * u.mag,
+                "targetname": ["3552", "3552", "12893", "12893"],
+            }
+        )
+        data = obs.supplement(service="jplhorizons", modify_fieldnames="obs")
+        assert len(set(data["targetname"])) == 2

--- a/sbpy/data/tests/test_orbit_remote.py
+++ b/sbpy/data/tests/test_orbit_remote.py
@@ -19,84 +19,90 @@ class TestOrbitFromHorizons:
     def test_now(self):
         # current epoch
         now = Time.now()
-        data = Orbit.from_horizons('Ceres')
-        assert_allclose(data['epoch'].utc.jd, now.utc.jd)
+        data = Orbit.from_horizons("Ceres")
+        assert_allclose(data["epoch"].utc.jd, now.utc.jd)
 
     def test_range_step(self):
         # date range - astropy.time.Time objects
-        epochs = {'start': Time('2018-01-02', format='iso'),
-                  'stop': Time('2018-01-05', format='iso'),
-                  'step': 6*u.h}
-        data = Orbit.from_horizons('Ceres', epochs=epochs)
+        epochs = {
+            "start": Time("2018-01-02", format="iso"),
+            "stop": Time("2018-01-05", format="iso"),
+            "step": 6 * u.h,
+        }
+        data = Orbit.from_horizons("Ceres", epochs=epochs)
         assert len(data.table) == 13
 
     def test_range_number(self):
         # date range - astropy.time.Time objects
-        epochs = {'start': Time('2018-01-02', format='iso'),
-                  'stop': Time('2018-01-05', format='iso'),
-                  'number': 10}
-        data = Orbit.from_horizons('Ceres', epochs=epochs)
+        epochs = {
+            "start": Time("2018-01-02", format="iso"),
+            "stop": Time("2018-01-05", format="iso"),
+            "number": 10,
+        }
+        data = Orbit.from_horizons("Ceres", epochs=epochs)
         assert len(data.table) == 10
 
     def test_mult_epochs(self):
         # discrete epochs - astropy.time.Time objects
-        epochs = Time(['2018-01-02', '2018-01-05'], format='iso', scale='tdb')
-        data = Orbit.from_horizons('Ceres', epochs=epochs)
+        epochs = Time(["2018-01-02", "2018-01-05"], format="iso", scale="tdb")
+        data = Orbit.from_horizons("Ceres", epochs=epochs)
         assert len(data.table) == 2
 
     def test_mult_objects(self):
         # query two objects
-        data = Orbit.from_horizons(['Ceres', 'Pallas'])
+        data = Orbit.from_horizons(["Ceres", "Pallas"])
         assert len(data.table) == 2
 
     def test_bib(self):
         # test bib service
         with bib.Tracking():
-            Orbit.from_horizons(['Ceres', 'Pallas'])
-            assert 'sbpy.data.orbit.Orbit.from_horizons' in bib.to_text()
+            Orbit.from_horizons(["Ceres", "Pallas"])
+            assert "sbpy.data.orbit.Orbit.from_horizons" in bib.show()
 
     def test_queryfail(self):
         with pytest.raises(QueryError):
-            Orbit.from_horizons('target does not exist')
+            Orbit.from_horizons("target does not exist")
 
     def test_timescale(self):
         # test same timescale
-        time = Time('2020-01-01 00:00', format='iso', scale='tdb')
+        time = Time("2020-01-01 00:00", format="iso", scale="tdb")
         a = Orbit.from_horizons(1, epochs=time)
-        assert a['epoch'].scale == 'tdb'
-        assert a['epoch'].tdb.jd == 2458849.5
+        assert a["epoch"].scale == "tdb"
+        assert a["epoch"].tdb.jd == 2458849.5
 
         # test different timescale (and check for warning)
-        time = Time('2020-01-01 00:00', format='iso', scale='utc')
+        time = Time("2020-01-01 00:00", format="iso", scale="utc")
         with warnings.catch_warnings(record=True) as w:
             a = Orbit.from_horizons(1, epochs=time)
             for i in range(len(w)):
                 print(w[i])
-            assert any(["astroquery.jplhorizons" in str(w[i].message)
-                        for i in range(len(w))])
-        assert a['epoch'].scale == 'tdb'
-        assert_allclose(a['epoch'][0].tdb.jd, 2458849.49919926)
+            assert any(
+                ["astroquery.jplhorizons" in str(w[i].message) for i in range(len(w))]
+            )
+        assert a["epoch"].scale == "tdb"
+        assert_allclose(a["epoch"][0].tdb.jd, 2458849.49919926)
 
     def test_output_epochs(self):
         # all tdb
-        epochs = Time(2437675.5, format='jd', scale='tdb')
+        epochs = Time(2437675.5, format="jd", scale="tdb")
         a = Orbit.from_horizons(1, epochs=epochs)
-        assert a['epoch'][0].scale == 'tdb'
+        assert a["epoch"][0].scale == "tdb"
 
         # request tai, expect tdb and warning
-        epochs = Time([2437655.5, 2437675.5], format='jd', scale='tai')
+        epochs = Time([2437655.5, 2437675.5], format="jd", scale="tai")
         with warnings.catch_warnings(record=True) as w:
             a = Orbit.from_horizons(1, epochs=epochs)
-            assert any(["astroquery.jplhorizons" in str(w[i].message)
-                        for i in range(len(w))])
-        assert a['epoch'].scale == 'tdb'
+            assert any(
+                ["astroquery.jplhorizons" in str(w[i].message) for i in range(len(w))]
+            )
+        assert a["epoch"].scale == "tdb"
 
 
 @pytest.mark.remote_data
 class TestOrbitFromMPC:
 
     def test_single(self):
-        a = Orbit.from_mpc('Ceres')
+        a = Orbit.from_mpc("Ceres")
         assert len(a) == 1
 
     def test_multiple(self):
@@ -105,91 +111,89 @@ class TestOrbitFromMPC:
 
     def test_break(self):
         with pytest.raises(TargetNameParseError):
-            Orbit.from_mpc('does not exist')
+            Orbit.from_mpc("does not exist")
 
 
 @pytest.mark.remote_data
 class TestOOTransform:
     def test_oo_transform(self):
-        """ test oo_transform method"""
+        """test oo_transform method"""
 
         pytest.importorskip("pyoorb")
 
-        orbit = Orbit.from_horizons('Ceres')
+        orbit = Orbit.from_horizons("Ceres")
 
-        cart_orbit = orbit.oo_transform('CART')
+        cart_orbit = orbit.oo_transform("CART")
 
-        kep_orbit = cart_orbit.oo_transform('KEP')
-        u.isclose(orbit['a'][0], kep_orbit['a'][0])
-        u.isclose(orbit['e'][0], kep_orbit['e'][0])
-        u.isclose(orbit['i'][0], kep_orbit['i'][0])
-        u.isclose(orbit['Omega'][0], kep_orbit['Omega'][0])
-        u.isclose(orbit['w'][0], kep_orbit['w'][0])
-        u.isclose(orbit['M'][0], kep_orbit['M'][0])
-        u.isclose(orbit['epoch'][0].utc.jd, kep_orbit['epoch'][0].utc.jd)
+        kep_orbit = cart_orbit.oo_transform("KEP")
+        u.isclose(orbit["a"][0], kep_orbit["a"][0])
+        u.isclose(orbit["e"][0], kep_orbit["e"][0])
+        u.isclose(orbit["i"][0], kep_orbit["i"][0])
+        u.isclose(orbit["Omega"][0], kep_orbit["Omega"][0])
+        u.isclose(orbit["w"][0], kep_orbit["w"][0])
+        u.isclose(orbit["M"][0], kep_orbit["M"][0])
+        u.isclose(orbit["epoch"][0].utc.jd, kep_orbit["epoch"][0].utc.jd)
 
-        com_orbit = orbit.oo_transform('COM')
-        kep_orbit = com_orbit.oo_transform('KEP')
-        u.isclose(orbit['a'][0], kep_orbit['a'][0])
-        u.isclose(orbit['e'][0], kep_orbit['e'][0])
-        u.isclose(orbit['i'][0], kep_orbit['i'][0])
-        u.isclose(orbit['Omega'][0], kep_orbit['Omega'][0])
-        u.isclose(orbit['w'][0], kep_orbit['w'][0])
-        u.isclose(orbit['M'][0], kep_orbit['M'][0])
-        u.isclose(orbit['epoch'][0].utc.jd, kep_orbit['epoch'][0].utc.jd)
+        com_orbit = orbit.oo_transform("COM")
+        kep_orbit = com_orbit.oo_transform("KEP")
+        u.isclose(orbit["a"][0], kep_orbit["a"][0])
+        u.isclose(orbit["e"][0], kep_orbit["e"][0])
+        u.isclose(orbit["i"][0], kep_orbit["i"][0])
+        u.isclose(orbit["Omega"][0], kep_orbit["Omega"][0])
+        u.isclose(orbit["w"][0], kep_orbit["w"][0])
+        u.isclose(orbit["M"][0], kep_orbit["M"][0])
+        u.isclose(orbit["epoch"][0].utc.jd, kep_orbit["epoch"][0].utc.jd)
 
     def test_timescales(self):
         pytest.importorskip("pyoorb")
 
-        orbit = Orbit.from_horizons('Ceres')
-        orbit['epoch'] = orbit['epoch'].tdb
+        orbit = Orbit.from_horizons("Ceres")
+        orbit["epoch"] = orbit["epoch"].tdb
 
-        cart_orbit = orbit.oo_transform('CART')
+        cart_orbit = orbit.oo_transform("CART")
 
-        kep_orbit = cart_orbit.oo_transform('KEP')
-        u.isclose(orbit['a'][0], kep_orbit['a'][0])
-        u.isclose(orbit['e'][0], kep_orbit['e'][0])
-        u.isclose(orbit['i'][0], kep_orbit['i'][0])
-        u.isclose(orbit['Omega'][0], kep_orbit['Omega'][0])
-        u.isclose(orbit['w'][0], kep_orbit['w'][0])
-        u.isclose(orbit['M'][0], kep_orbit['M'][0])
-        u.isclose(orbit['epoch'][0].utc.jd, kep_orbit['epoch'][0].utc.jd)
+        kep_orbit = cart_orbit.oo_transform("KEP")
+        u.isclose(orbit["a"][0], kep_orbit["a"][0])
+        u.isclose(orbit["e"][0], kep_orbit["e"][0])
+        u.isclose(orbit["i"][0], kep_orbit["i"][0])
+        u.isclose(orbit["Omega"][0], kep_orbit["Omega"][0])
+        u.isclose(orbit["w"][0], kep_orbit["w"][0])
+        u.isclose(orbit["M"][0], kep_orbit["M"][0])
+        u.isclose(orbit["epoch"][0].utc.jd, kep_orbit["epoch"][0].utc.jd)
 
-        com_orbit = orbit.oo_transform('COM')
-        kep_orbit = com_orbit.oo_transform('KEP')
-        u.isclose(orbit['a'][0], kep_orbit['a'][0])
-        u.isclose(orbit['e'][0], kep_orbit['e'][0])
-        u.isclose(orbit['i'][0], kep_orbit['i'][0])
-        u.isclose(orbit['Omega'][0], kep_orbit['Omega'][0])
-        u.isclose(orbit['w'][0], kep_orbit['w'][0])
-        u.isclose(orbit['M'][0], kep_orbit['M'][0])
-        u.isclose(orbit['epoch'][0].utc.jd, kep_orbit['epoch'][0].utc.jd)
+        com_orbit = orbit.oo_transform("COM")
+        kep_orbit = com_orbit.oo_transform("KEP")
+        u.isclose(orbit["a"][0], kep_orbit["a"][0])
+        u.isclose(orbit["e"][0], kep_orbit["e"][0])
+        u.isclose(orbit["i"][0], kep_orbit["i"][0])
+        u.isclose(orbit["Omega"][0], kep_orbit["Omega"][0])
+        u.isclose(orbit["w"][0], kep_orbit["w"][0])
+        u.isclose(orbit["M"][0], kep_orbit["M"][0])
+        u.isclose(orbit["epoch"][0].utc.jd, kep_orbit["epoch"][0].utc.jd)
 
-        assert kep_orbit['epoch'].scale == 'tdb'
+        assert kep_orbit["epoch"].scale == "tdb"
 
 
 @pytest.mark.remote_data
 class TestOOPropagate:
     def test_oo_propagate(self):
-        """ test oo_propagate method"""
+        """test oo_propagate method"""
 
         pytest.importorskip("pyoorb")
 
-        orbit = Orbit.from_horizons('Ceres')
-        epoch = Time(Time.now().jd + 100, format='jd', scale='utc')
+        orbit = Orbit.from_horizons("Ceres")
+        epoch = Time(Time.now().jd + 100, format="jd", scale="utc")
 
-        future_orbit = Orbit.from_horizons('Ceres',
-                                           epochs=Time(epoch, format='jd',
-                                                       scale='utc').tdb)
+        future_orbit = Orbit.from_horizons(
+            "Ceres", epochs=Time(epoch, format="jd", scale="utc").tdb
+        )
 
         oo_orbit = orbit.oo_propagate(epoch)
 
-        elements = ['a', 'e', 'i', 'Omega', 'w', 'M']
-        assert all([u.isclose(oo_orbit[k][0], future_orbit[k][0])
-                    for k in elements])
-        assert u.isclose(oo_orbit['epoch'][0].utc.jd,
-                         future_orbit['epoch'][0].utc.jd)
-        assert oo_orbit['epoch'].scale == 'utc'
+        elements = ["a", "e", "i", "Omega", "w", "M"]
+        assert all([u.isclose(oo_orbit[k][0], future_orbit[k][0]) for k in elements])
+        assert u.isclose(oo_orbit["epoch"][0].utc.jd, future_orbit["epoch"][0].utc.jd)
+        assert oo_orbit["epoch"].scale == "utc"
 
 
 @pytest.mark.remote_data
@@ -198,15 +202,18 @@ class TestTisserand:
         """Test against JPL values for -0.605 using epoch JD = 2449400.5
         elements.
         """
-        epoch = Time(2449400.5, format='jd', scale='tdb')
-        halley = Orbit.from_horizons('1P', id_type='designation',
-                                     closest_apparition=True, epochs=epoch)
+        epoch = Time(2449400.5, format="jd", scale="tdb")
+        halley = Orbit.from_horizons(
+            "1P", id_type="designation", closest_apparition=True, epochs=epoch
+        )
         jupiter = Orbit.from_horizons(599, id_type=None, epochs=epoch)
         assert u.isclose(halley.tisserand(jupiter), -0.60495016)
 
-        chariklo = Orbit.from_horizons('chariklo', id_type='name',
-                                       closest_apparition=True, epochs=epoch)
-        assert u.allclose(chariklo.tisserand(['599', '699', '799', '899'],
-                                             epoch=epoch),
-                          [3.47740968, 2.92990768, 2.85749431, 3.22074493],
-                          atol=1e-5)
+        chariklo = Orbit.from_horizons(
+            "chariklo", id_type="name", closest_apparition=True, epochs=epoch
+        )
+        assert u.allclose(
+            chariklo.tisserand(["599", "699", "799", "899"], epoch=epoch),
+            [3.47740968, 2.92990768, 2.85749431, 3.22074493],
+            atol=1e-5,
+        )

--- a/sbpy/units/__init__.py
+++ b/sbpy/units/__init__.py
@@ -5,7 +5,7 @@
 import astropy
 from packaging.version import Version as Version
 
-from .core import *
+from .core import *  # noqa: F401, F403
 
 
 ###########################################################################

--- a/sbpy/units/__init__.py
+++ b/sbpy/units/__init__.py
@@ -12,7 +12,7 @@ from .core import *
 # DOCSTRING
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
-if Version(astropy.__version__) <= Version("7.2.0"):
+if Version(astropy.__version__) < Version("7.2.0"):
     from astropy.units.utils import generate_unit_summary as _generate_unit_summary
 else:
     from astropy.units.docgen import generate_unit_summary as _generate_unit_summary

--- a/sbpy/units/__init__.py
+++ b/sbpy/units/__init__.py
@@ -1,17 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-"""Common planetary astronomy units.
+"""Common planetary astronomy units."""
 
-"""
+import astropy
+from packaging.version import Version as Version
 
 from .core import *
 
 
 ###########################################################################
 # DOCSTRING
-
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
-from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+if Version(astropy.__version__) <= Version("7.2.0"):
+    from astropy.units.utils import generate_unit_summary as _generate_unit_summary
+else:
+    from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
+
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/sbpy/units/__init__.py
+++ b/sbpy/units/__init__.py
@@ -18,4 +18,4 @@ else:
     from astropy.units.docgen import generate_unit_summary as _generate_unit_summary
 
 if __doc__ is not None:
-    __doc__ += _generate_unit_summary(globals())
+    __doc__ += "\n\n" + _generate_unit_summary(globals())


### PR DESCRIPTION
* `generate_unit_summary` was moved from astropy.units.utils to astropy.units.docgen in astropy 7.2
* Also remove version from __doctest_requires__ parameters.  They should only be importable strings.
* update remote tests to pass or mark with expected failures.  Revisit with astroquery 0.4.12
* collect tests on CI with oldest deps

