### PR TITLE
Example in documentation showing color computation for a reddened source

### DIFF
--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -145,31 +145,31 @@ the ``bandpass`` function from the `~sbpy.photometry` module.  The following
 example computes the LSST g-r color of an object with an 18% spectral gradient
 (normalized to 550 nm).
 
-Create a reddened source (e.g., a comet):
+First, create a reddened source (e.g., a comet).  Then, specify the bandpasses
+to be used for the desired color calculation (in this example, LSST g and r),
+and calculate the specified color of the comet, where the list of available
+bandpasses and their sources may be found in the `~sbpy.photometry.bandpass`
+documentation:
 
 .. doctest-requires:: synphot
 
   >>> import astropy.units as u
   >>> from sbpy.calib import Sun
   >>> from sbpy.spectroscopy import SpectralGradient
+  >>> from sbpy.photometry import bandpass
   >>> import sbpy.units as sbu
+  >>>
   >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
   >>> sun = Sun.from_builtin("calspec")  # doctest: +REMOTE_DATA
   >>> comet = sun.redden(S)
-
-Specify the bandpasses to be used for the desired color calculation (in this
-example, LSST g and r), and calculate the specified color of the comet, where
-the list of available bandpasses and their sources may be found in the
-`~sbpy.photometry.bandpass` documentation:
-
-  >>> from sbpy.photometry import bandpass
+  >>>
   >>> bp_g = bandpass("LSST g")
   >>> bp_r = bandpass("LSST r")
   >>> _, r = comet.observe_bandpass(bp_r, unit=u.ABmag)
   >>> _, g = comet.observe_bandpass(bp_g, unit=u.ABmag)
   >>> print("g-r =", g - r)
   g-r = 0.7007308548908533 mag
-  
+
 Reference/API
 -------------
 .. automodapi:: sbpy.spectroscopy

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -140,16 +140,21 @@ The following example reddens a solar spectrum:
       ylabel='Flux density ({})'.format(fluxd_unit))
   plt.tight_layout()
 
-Colors using specified filters of a reddened object can also be computed using
-the ``bandpass`` function from the `~sbpy.photometry` module.  The following
-example computes the LSST g-r color of an object with an 18% spectral gradient
-(normalized to 550 nm).
+Conversion to Photometry
+------------------------
+
+Magnitudes using specified filters of a reddened object, which can then be
+used to compute equivalent broadband colors for an object with the specified
+spectral gradient, can be computed using the ``bandpass`` function from the
+`~sbpy.photometry` module.  The following example computes the LSST g-r
+color of an object with a spectral gradient of 18%/100 nm (normalized to 550 nm).
 
 First, create a reddened source (e.g., a comet).  Then, specify the bandpasses
 to be used for the desired color calculation (in this example, LSST g and r),
 and calculate the specified color of the comet, where the list of available
 bandpasses and their sources may be found in the `~sbpy.photometry.bandpass`
-documentation:
+documentation.  Alternatively, any other filter bandpass can also be provided
+as a `~synphot.spectrum.SpectralElement` object and used instead:
 
 .. doctest-requires:: synphot
 .. doctest-remote-data:: 

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -140,7 +140,29 @@ The following example reddens a solar spectrum:
       ylabel='Flux density ({})'.format(fluxd_unit))
   plt.tight_layout()
 
+Colors using specified filters of a reddened object can also be computed using
+the ``bandpass`` function from the `~sbpy.photometry` module.  The following
+example computes the LSST g-r color of an object with an 18% spectral slope.
 
+.. doctest-requires:: synphot
+
+  >>> import astropy.units as u
+  >>> from sbpy.calib import Sun
+  >>> from sbpy.photometry import bandpass
+  >>> from sbpy.spectroscopy import SpectralGradient
+  >>> import sbpy.units as sbu
+
+  >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
+  >>> sun = Sun.from_builtin("calspec")
+  >>> comet = sun.redden(S)
+  >>> bp_g = bandpass("LSST g")
+  >>> bp_r = bandpass("LSST r")
+
+  >>> _, r = comet.observe_bandpass(bp_r, unit=u.ABmag)
+  >>> _, g = comet.observe_bandpass(bp_g, unit=u.ABmag)
+  >>> print("g-r =", g - r)
+
+  
 Reference/API
 -------------
 .. automodapi:: sbpy.spectroscopy

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -142,7 +142,10 @@ The following example reddens a solar spectrum:
 
 Colors using specified filters of a reddened object can also be computed using
 the ``bandpass`` function from the `~sbpy.photometry` module.  The following
-example computes the LSST g-r color of an object with an 18% spectral slope.
+example computes the LSST g-r color of an object with an 18% spectral gradient
+(normalized to 550 nm).
+
+Create a reddened source (e.g., a comet):
 
 .. doctest-requires:: synphot
 
@@ -151,17 +154,21 @@ example computes the LSST g-r color of an object with an 18% spectral slope.
   >>> from sbpy.photometry import bandpass
   >>> from sbpy.spectroscopy import SpectralGradient
   >>> import sbpy.units as sbu
-
   >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
   >>> sun = Sun.from_builtin("calspec")
   >>> comet = sun.redden(S)
+
+Specify the bandpasses to be used for the desired color calculation (in this
+example, LSST g and r), and calculate the specified color of the comet, where
+the list of available bandpasses and their sources may be found in the
+`~sbpy.photometry.bandpass` documentation:
+
   >>> bp_g = bandpass("LSST g")
   >>> bp_r = bandpass("LSST r")
-
   >>> _, r = comet.observe_bandpass(bp_r, unit=u.ABmag)
   >>> _, g = comet.observe_bandpass(bp_g, unit=u.ABmag)
   >>> print("g-r =", g - r)
-
+  g-r = 0.7007308548908533 mag
   
 Reference/API
 -------------

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -155,7 +155,7 @@ Create a reddened source (e.g., a comet):
   >>> from sbpy.spectroscopy import SpectralGradient
   >>> import sbpy.units as sbu
   >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
-  >>> sun = Sun.from_builtin("calspec")
+  >>> sun = Sun.from_builtin("calspec")  # doctest: +REMOTE_DATA
   >>> comet = sun.redden(S)
 
 Specify the bandpasses to be used for the desired color calculation (in this

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -152,6 +152,7 @@ bandpasses and their sources may be found in the `~sbpy.photometry.bandpass`
 documentation:
 
 .. doctest-requires:: synphot
+.. doctest-remote-data:: 
 
   >>> import astropy.units as u
   >>> from sbpy.calib import Sun
@@ -160,8 +161,8 @@ documentation:
   >>> import sbpy.units as sbu
   >>>
   >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
-  >>> sun = Sun.from_builtin("calspec")  # doctest: +REMOTE_DATA
-  >>> comet = sun.redden(S)              # doctest: +REMOTE_DATA
+  >>> sun = Sun.from_builtin("calspec")
+  >>> comet = sun.redden(S)
   >>>
   >>> bp_g = bandpass("LSST g")
   >>> bp_r = bandpass("LSST r")

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -151,7 +151,6 @@ Create a reddened source (e.g., a comet):
 
   >>> import astropy.units as u
   >>> from sbpy.calib import Sun
-  >>> from sbpy.photometry import bandpass
   >>> from sbpy.spectroscopy import SpectralGradient
   >>> import sbpy.units as sbu
   >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
@@ -163,6 +162,7 @@ example, LSST g and r), and calculate the specified color of the comet, where
 the list of available bandpasses and their sources may be found in the
 `~sbpy.photometry.bandpass` documentation:
 
+  >>> from sbpy.photometry import bandpass
   >>> bp_g = bandpass("LSST g")
   >>> bp_r = bandpass("LSST r")
   >>> _, r = comet.observe_bandpass(bp_r, unit=u.ABmag)

--- a/docs/sbpy/spectroscopy/index.rst
+++ b/docs/sbpy/spectroscopy/index.rst
@@ -161,7 +161,7 @@ documentation:
   >>>
   >>> S = SpectralGradient(18 * u.percent / sbu.hundred_nm, wave0=550 * u.nm)
   >>> sun = Sun.from_builtin("calspec")  # doctest: +REMOTE_DATA
-  >>> comet = sun.redden(S)
+  >>> comet = sun.redden(S)              # doctest: +REMOTE_DATA
   >>>
   >>> bp_g = bandpass("LSST g")
   >>> bp_r = bandpass("LSST r")


### PR DESCRIPTION
adding new example to spectroscopy documentation for computing the color of a reddened source in specified filters from sbpy.photometry.bandpass