### PR TITLE
Fix: synphot keyword argument deprecation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,17 @@ sbpy.photometry
 - Added Rubin Observatory's LSSTCam filter set to `bandpass()`. [#431]
 
 
+Bug Fixes
+---------
+
+sbpy.spectroscopy
+^^^^^^^^^^^^^^^^^
+
+- Avoid deprecation warning on flux_unit and wave_unit keyword arguments in
+  `sbpy.spectroscopy.sources.SpectralSource.from_file` when using synphot's
+  read_fits_spec. [#447]
+
+
 v0.6.0 (2025-12-02)
 ===================
 

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -141,7 +141,14 @@ class SpectralSource(ABC):
         else:
             fn = filename
 
-        spec = read_spec(fn, wave_unit=wave_unit, flux_unit=flux_unit)
+        # flux_unit and wave_unit were deprecated for FITS files in synphot 1.4;
+        # only use them if requested
+        read_kwargs = {}
+        if wave_unit is not None:
+            read_kwargs["wave_unit"] = wave_unit
+            read_kwargs["flux_unit"] = flux_unit
+
+        spec = read_spec(fn, **read_kwargs)
         i = np.isfinite(spec[1] * spec[2])
         source = synphot.SourceSpectrum(
             synphot.Empirical1D, points=spec[1][i], lookup_table=spec[2][i],

--- a/sbpy/spectroscopy/sources.py
+++ b/sbpy/spectroscopy/sources.py
@@ -137,7 +137,7 @@ class SpectralSource(ABC):
 
         # URL cache because synphot.SourceSpectrum.from_file does not
         if _is_url(filename):
-            fn = download_file(filename, cache=True)
+            fn = download_file(filename, cache=cache)
         else:
             fn = filename
 


### PR DESCRIPTION
* Only use flux_unit and wave_unit with synphot's read_*_spec when requested.
* Respect the cache parameter on SpectralSource.from_file